### PR TITLE
Update SNS.swift

### DIFF
--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -68,9 +68,9 @@ extension SNSEvent.Message: Decodable {
         case messageAttributes = "MessageAttributes"
         case signatureVersion = "SignatureVersion"
         case timestamp = "Timestamp"
-        case signingCertURL = "SigningCertUrl"
+        case signingCertURL = "SigningCertURL"
         case message = "Message"
-        case unsubscribeUrl = "UnsubscribeUrl"
+        case unsubscribeUrl = "UnsubscribeURL"
         case subject = "Subject"
     }
 }


### PR DESCRIPTION
Received SNS object has uppercased "URL" coding keys.

### Motivation:
The received SNS object has uppercased "URL" coding keys. The object can not be decoded otherwise. Currently, the coding keys contain a lower case "Url", for example "SigningCertUrl" but should be "SigningCertURL".

```
{
  "Timestamp": "2021-10-08T11:18:40.043Z",
  "SigningCertURL": "https://sns.eu ****",
  "MessageId": "776e6308-8c44-5ee ****",
  "Type": "Notification",
  "SignatureVersion": "1",
  "Signature": "s71McLg8d9OP86E4a *****",
  "TopicArn": "arn:aws:sns:eu-west-1:06 *****",
  "UnsubscribeURL": "https://sns.eu-w****",
  "Message": "{\"action\":\"upload_document_version\",\"entityId\":\"1633691914791-1796da229943***aace80d5e023f3***c\",\"entityType\":\"DocumentVersion\",\"organizationId\":\"d-9367073c36\",\"parentEntityId\":\"516d7ab0537aff5d39a469439c*****2d0d4\",\"parentEntityType\":\"Document\"}"
}
```

### Modifications:

The coding keys string value has been changed.

### Result:

We can now use the decoded object with dot notation.
