### PR TITLE
Make APIGatewayV2Request authorizer claims optional

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -28,7 +28,7 @@ public struct APIGatewayV2Request: Codable {
         public struct Authorizer: Codable {
             /// JWT contains JWT authorizer information for the request context.
             public struct JWT: Codable {
-                public let claims: [String: String]
+                public let claims: [String: String]?
                 public let scopes: [String]?
             }
 


### PR DESCRIPTION
Make APIGatewayV2Request authorizer claims optional.

### Motivation:

The current non-optional claims property is not compatible with the Lambda Runtime Interface Emulator.

Aside from this, the AWS Docs specify a `null` value in this example: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format

### Modifications:

Make APIGatewayV2Request authorizer claims optional.

### Result:

APIGatewayV2Request authorizer claims is optional, allowing a nil value so that the Lambda Runtime Interface Emulator works with this library and so it's in accordance with the AWS docs.
