### PR TITLE
SES messageId event fix

### DIFF
--- a/Sources/AWSLambdaEvents/SES.swift
+++ b/Sources/AWSLambdaEvents/SES.swift
@@ -49,7 +49,7 @@ public struct SESEvent: Decodable {
         public let cc: [String]?
         @RFC5322DateTimeCoding public var date: Date
         public let from: [String]
-        public let messageId: String
+        public let messageId: String?
         public let returnPath: String?
         public let subject: String?
         public let to: [String]?


### PR DESCRIPTION
Make commonHeaders.messageId optional

### Motivation:

Sometimes the SES event does not provide a messageId in the commonHeaders section

### Result:

SES events without a messageId in commonHeaders decode