### PR TITLE
Allow for RFC5322 dates without a day

### DIFF
--- a/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
+++ b/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
@@ -91,18 +91,24 @@ public struct RFC5322DateTimeCoding: Decodable {
         if let bracket = string.firstIndex(of: "(") {
             string = String(string[string.startIndex ..< bracket].trimmingCharacters(in: .whitespaces))
         }
-        guard let date = Self.dateFormatter.date(from: string) else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription:
-                "Expected date to be in RFC5322 date-time format with fractional seconds, but `\(string)` is not in the correct format")
+        for formatter in Self.dateFormatters {
+            if let date = formatter.date(from: string) {
+                self.wrappedValue = date
+                return
+            }
         }
-        self.wrappedValue = date
+        throw DecodingError.dataCorruptedError(in: container, debugDescription:
+            "Expected date to be in RFC5322 date-time format, but `\(string)` is not in the correct format")
     }
 
-    private static let dateFormatter: DateFormatter = Self.createDateFormatter()
-    private static func createDateFormatter() -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEE, d MMM yyy HH:mm:ss z"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter
+    private static let dateFormatters: [DateFormatter] = Self.createDateFormatters()
+    private static func createDateFormatters() -> [DateFormatter] {
+        let formatterWithDay = DateFormatter()
+        formatterWithDay.dateFormat = "EEE, d MMM yyy HH:mm:ss z"
+        formatterWithDay.locale = Locale(identifier: "en_US_POSIX")
+        let formatterWithoutDay = DateFormatter()
+        formatterWithoutDay.dateFormat = "d MMM yyy HH:mm:ss z"
+        formatterWithoutDay.locale = Locale(identifier: "en_US_POSIX")
+        return [formatterWithDay, formatterWithoutDay]
     }
 }

--- a/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
+++ b/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
@@ -103,6 +103,8 @@ public struct RFC5322DateTimeCoding: Decodable {
 
     private static let dateFormatters: [DateFormatter] = Self.createDateFormatters()
     private static func createDateFormatters() -> [DateFormatter] {
+        // rfc5322 dates received in SES mails sometimes do not include the day, so need two dateformatters
+        // one with a day and one without
         let formatterWithDay = DateFormatter()
         formatterWithDay.dateFormat = "EEE, d MMM yyy HH:mm:ss z"
         formatterWithDay.locale = Locale(identifier: "en_US_POSIX")

--- a/Tests/AWSLambdaEventsTests/Utils/DateWrapperTests.swift
+++ b/Tests/AWSLambdaEventsTests/Utils/DateWrapperTests.swift
@@ -119,6 +119,19 @@ class DateWrapperTests: XCTestCase {
         XCTAssertEqual(event?.date.description, "2020-06-26 08:04:03 +0000")
     }
 
+    func testRFC5322DateTimeCodingWithoutDayWrapperSuccess() {
+        struct TestEvent: Decodable {
+            @RFC5322DateTimeCoding
+            var date: Date
+        }
+
+        let json = #"{"date":"5 Apr 2012 23:47:37 +0200"}"#
+        var event: TestEvent?
+        XCTAssertNoThrow(event = try JSONDecoder().decode(TestEvent.self, from: json.data(using: .utf8)!))
+
+        XCTAssertEqual(event?.date.description, "2012-04-05 21:47:37 +0000")
+    }
+
     func testRFC5322DateTimeCodingWrapperFailure() {
         struct TestEvent: Decodable {
             @RFC5322DateTimeCoding
@@ -133,7 +146,7 @@ class DateWrapperTests: XCTestCase {
             }
 
             XCTAssertEqual(context.codingPath.map(\.stringValue), ["date"])
-            XCTAssertEqual(context.debugDescription, "Expected date to be in RFC5322 date-time format with fractional seconds, but `\(date)` is not in the correct format")
+            XCTAssertEqual(context.debugDescription, "Expected date to be in RFC5322 date-time format, but `\(date)` is not in the correct format")
             XCTAssertNil(context.underlyingError)
         }
     }


### PR DESCRIPTION
Allow RFC5322 dates without a day to decode

### Motivation:

Sometimes the RFC5322 date in the email common headers does not include a day

### Modifications:

I added a second dateFormatter to `RFC5322DateTimeCoding` for dates that do not include a day and check against that as well as the standard one that also includes the day

### Result:

Emails whose date in their common headers does not include a day decode.
