### PR TITLE
Add Sendable support

### DIFF
--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -73,3 +73,10 @@ public struct ALBTargetGroupResponse: Codable {
         self.isBase64Encoded = isBase64Encoded
     }
 }
+
+#if swift(>=5.6)
+extension ALBTargetGroupRequest: Sendable {}
+extension ALBTargetGroupRequest.Context: Sendable {}
+extension ALBTargetGroupRequest.ELBContext: Sendable {}
+extension ALBTargetGroupResponse: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -106,3 +106,12 @@ public struct APIGatewayV2Response: Codable {
         self.cookies = cookies
     }
 }
+
+#if swift(>=5.6)
+extension APIGatewayV2Request: Sendable {}
+extension APIGatewayV2Request.Context: Sendable {}
+extension APIGatewayV2Request.Context.HTTP: Sendable {}
+extension APIGatewayV2Request.Context.Authorizer: Sendable {}
+extension APIGatewayV2Request.Context.Authorizer.JWT: Sendable {}
+extension APIGatewayV2Response: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -87,3 +87,10 @@ public struct APIGatewayResponse: Codable {
         self.isBase64Encoded = isBase64Encoded
     }
 }
+
+#if swift(>=5.6)
+extension APIGatewayRequest: Sendable {}
+extension APIGatewayRequest.Context: Sendable {}
+extension APIGatewayRequest.Context.Identity: Sendable {}
+extension APIGatewayResponse: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/AWSRegion.swift
+++ b/Sources/AWSLambdaEvents/AWSRegion.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -90,3 +90,7 @@ extension AWSRegion: Codable {
         try container.encode(self.rawValue)
     }
 }
+
+#if swift(>=5.6)
+extension AWSRegion: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -163,3 +163,15 @@ public enum AppSyncResponse<ResultType: Encodable>: Encodable {
 }
 
 public typealias AppSyncJSONResponse = AppSyncResponse<String>
+
+#if swift(>=5.6)
+extension AppSyncEvent: Sendable {}
+extension AppSyncEvent.ArgumentValue: Sendable {}
+extension AppSyncEvent.Request: Sendable {}
+extension AppSyncEvent.Info: Sendable {}
+extension AppSyncEvent.Identity: Sendable {}
+extension AppSyncEvent.Identity.CognitoUserPoolIdentity: Sendable {}
+extension AppSyncEvent.Identity.IAMIdentity: Sendable {}
+extension AppSyncResponse: Sendable where ResultType: Sendable {}
+
+#endif

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -173,5 +173,4 @@ extension AppSyncEvent.Identity: Sendable {}
 extension AppSyncEvent.Identity.CognitoUserPoolIdentity: Sendable {}
 extension AppSyncEvent.Identity.IAMIdentity: Sendable {}
 extension AppSyncResponse: Sendable where ResultType: Sendable {}
-
 #endif

--- a/Sources/AWSLambdaEvents/Cloudwatch.swift
+++ b/Sources/AWSLambdaEvents/Cloudwatch.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.6)
+@preconcurrency import struct Foundation.Date
+#else
 import struct Foundation.Date
+#endif
 
 /// EventBridge has the same events/notification types as CloudWatch
 typealias EventBridgeEvent = CloudwatchEvent
@@ -130,3 +134,9 @@ public enum CloudwatchDetails {
         let type: Any
     }
 }
+
+#if swift(>=5.6)
+extension CloudwatchEvent: Sendable where Detail: Sendable {}
+extension CloudwatchDetails.EC2: Sendable {}
+extension CloudwatchDetails.Scheduled: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/DynamoDB.swift
+++ b/Sources/AWSLambdaEvents/DynamoDB.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.6)
+@preconcurrency import struct Foundation.Date
+#else
 import struct Foundation.Date
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
 public struct DynamoDBEvent: Decodable {
@@ -930,3 +934,13 @@ extension DynamoDBEvent.AttributeValue {
         }
     }
 }
+
+#if swift(>=5.6)
+extension DynamoDBEvent: Sendable {}
+extension DynamoDBEvent.EventRecord: Sendable {}
+extension DynamoDBEvent.StreamRecord: Sendable {}
+extension DynamoDBEvent.UserIdentity: Sendable {}
+extension DynamoDBEvent.OperationType: Sendable {}
+extension DynamoDBEvent.AttributeValue: Sendable {}
+extension DynamoDBEvent.StreamViewType: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/S3.swift
+++ b/Sources/AWSLambdaEvents/S3.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -77,3 +77,13 @@ public struct S3Event: Decodable {
         public let sequencer: String
     }
 }
+
+#if swift(>=5.6)
+extension S3Event: Sendable {}
+extension S3Event.Bucket: Sendable {}
+extension S3Event.Entity: Sendable {}
+extension S3Event.Object: Sendable {}
+extension S3Event.Record: Sendable {}
+extension S3Event.RequestParameters: Sendable {}
+extension S3Event.UserIdentity: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/SES.swift
+++ b/Sources/AWSLambdaEvents/SES.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -96,3 +96,17 @@ public struct SESEvent: Decodable {
         case processingFailed = "PROCESSING_FAILED"
     }
 }
+
+#if swift(>=5.6)
+extension SESEvent: Sendable {}
+extension SESEvent.Record: Sendable {}
+extension SESEvent.Message: Sendable {}
+extension SESEvent.Mail: Sendable {}
+extension SESEvent.Receipt: Sendable {}
+extension SESEvent.CommonHeaders: Sendable {}
+extension SESEvent.Action: Sendable {}
+extension SESEvent.Header: Sendable {}
+extension SESEvent.DMARCPolicy: Sendable {}
+extension SESEvent.Verdict: Sendable {}
+extension SESEvent.Status: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -104,3 +104,10 @@ extension SNSEvent.Message.Attribute: Decodable {
         }
     }
 }
+
+#if swift(>=5.6)
+extension SNSEvent: Sendable {}
+extension SNSEvent.Record: Sendable {}
+extension SNSEvent.Message: Sendable {}
+extension SNSEvent.Message.Attribute: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/SQS.swift
+++ b/Sources/AWSLambdaEvents/SQS.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -93,3 +93,9 @@ extension SQSEvent.Message.Attribute: Decodable {
         }
     }
 }
+
+#if swift(>=5.6)
+extension SQSEvent: Sendable {}
+extension SQSEvent.Message: Sendable {}
+extension SQSEvent.Message.Attribute: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
+++ b/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.6)
+@preconcurrency import struct Foundation.Date
+#else
 import struct Foundation.Date
+#endif
 import class Foundation.DateFormatter
 import struct Foundation.Locale
 import struct Foundation.TimeZone
@@ -114,3 +118,9 @@ public struct RFC5322DateTimeCoding: Decodable {
         return [formatterWithDay, formatterWithoutDay]
     }
 }
+
+#if swift(>=5.6)
+extension ISO8601Coding: Sendable {}
+extension ISO8601WithFractionalSecondsCoding: Sendable {}
+extension RFC5322DateTimeCoding: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -158,7 +158,7 @@ extension HTTPResponseStatus: Codable {
 
 extension String {
     internal var isValidHTTPToken: Bool {
-        self.utf8.allSatisfy { (char) -> Bool in
+        self.utf8.allSatisfy { char -> Bool in
             switch char {
             case UInt8(ascii: "a") ... UInt8(ascii: "z"),
                  UInt8(ascii: "A") ... UInt8(ascii: "Z"),
@@ -185,3 +185,8 @@ extension String {
         }
     }
 }
+
+#if swift(>=5.6)
+extension HTTPMethod: Sendable {}
+extension HTTPResponseStatus: Sendable {}
+#endif

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -19,7 +19,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-2018/YEARS/' -e 's/2017-2020/YEARS/' -e 's/2017-2021/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/'
+    sed -e 's/2017-2018/YEARS/' -e 's/2017-2020/YEARS/' -e 's/2017-2021/YEARS/' -e 's/2017-2022/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
This is an alternative to: #13. The main difference is that we don't introduce new `Protocols`, which only inherit from `Decodable` and `Sendable`. For this reason adopters don't need to learn about our helper protocols. Let me know what you think.

As a side note: I still really dislike the Date propertyWrappers and I still consider them an anti-pattern, which only purpose is to work around Codable limitations.