### PR TITLE
Expose Authorizer claims

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -35,6 +35,11 @@ public struct APIGatewayRequest: Codable {
             public let accountId: String?
         }
 
+        public struct Authorizer: Codable {
+            public let claims: [String: String]
+            public let scopes: [String]?
+        }
+
         public let resourceId: String
         public let apiId: String
         public let resourcePath: String
@@ -44,6 +49,7 @@ public struct APIGatewayRequest: Codable {
         public let stage: String
 
         public let identity: Identity
+        public let authorizer: Authorizer?
         public let extendedRequestId: String?
         public let path: String
     }


### PR DESCRIPTION
_Expose Authorizer claims_

### Motivation:

_Currecnt version doesn't expose Cognito signed user details_

### Modifications:

_Added an option field, that doesnt break existing code_

### Result:

_*APIGateway.Request.requestContext.authorizer?* is now available_
