### PR TITLE
Update SNSEvent.Message Coding Keys

### DIFF
--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -68,9 +68,9 @@ extension SNSEvent.Message: Decodable {
         case messageAttributes = "MessageAttributes"
         case signatureVersion = "SignatureVersion"
         case timestamp = "Timestamp"
-        case signingCertURL = "SigningCertURL"
+        case signingCertURL = "SigningCertUrl"
         case message = "Message"
-        case unsubscribeURL = "UnsubscribeURL"
+        case unsubscribeURL = "UnsubscribeUrl"
         case subject = "Subject"
     }
 }

--- a/Tests/AWSLambdaEventsTests/SNSTests.swift
+++ b/Tests/AWSLambdaEventsTests/SNSTests.swift
@@ -32,8 +32,8 @@ class SNSTests: XCTestCase {
             "Timestamp": "2020-01-08T14:18:51.203Z",
             "SignatureVersion": "1",
             "Signature": "LJMF/xmMH7A1gNy2unLA3hmzyf6Be+zS/Yeiiz9tZbu6OG8fwvWZeNOcEZardhSiIStc0TF7h9I+4Qz3omCntaEfayzTGmWN8itGkn2mfn/hMFmPbGM8gEUz3+jp1n6p+iqP3XTx92R0LBIFrU3ylOxSo8+SCOjA015M93wfZzwj0WPtynji9iAvvtf15d8JxPUu1T05BRitpFd5s6ZXDHtVQ4x/mUoLUN8lOVp+rs281/ZdYNUG/V5CwlyUDTOERdryTkBJ/GO1NNPa+6m04ywJFa5d+BC8mDcUcHhhXXjpTEbt8AHBmswK3nudHrVMRO/G4zmssxU2P7ii5+gCfA==",
-            "SigningCertURL": "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
-            "UnsubscribeURL": "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:079477498937:EventSources-SNSTopic-1NHENSE2MQKF5:6fabdb7f-b27e-456d-8e8a-14679db9e40c",
+            "SigningCertUrl": "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+            "UnsubscribeUrl": "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:079477498937:EventSources-SNSTopic-1NHENSE2MQKF5:6fabdb7f-b27e-456d-8e8a-14679db9e40c",
             "MessageAttributes": {
               "binary":{
                 "Type": "Binary",


### PR DESCRIPTION
Update `SNSEvent.Message` coding keys to match go models & documentation

### Motivation:

When trying to decode an `SNSEvent` as the lambda's event (using runtime `1.0.0-alpha.1`), I am getting:

```
2023-05-18T14:51:32+0000 warning Lambda : lifecycleIteration=16 lambda handler returned an error: requestDecoding(Swift.DecodingError.keyNotFound(CodingKeys(stringValue: "SigningCertURL", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "Records", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "Sns", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"SigningCertURL\", intValue: nil) (\"SigningCertURL\").", underlyingError: nil)))
```

It seems that the model's coding keys have changed with the proper keys being `SigningCertUrl` and `UnsubscribeUrl ` (as opposed to `SigningCertURL` and `UnsubscribeURL`).

https://github.com/aws/aws-lambda-go/blob/771b391678d3f54bfa38531774d656f5e0f2ab58/events/sns.go#L28
https://github.com/aws/aws-lambda-go/blob/771b391678d3f54bfa38531774d656f5e0f2ab58/events/sns.go#L30
https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html

### Modifications:

Update the coding key raw values for `SNSEvent.Message.signingCertURL` and `SNSEvent.Message.unsubscribeURL`

### Result:

Lamda handler can now successfully decode `SNSEvent` in then `handle(_:context:)` method.
