### PR TITLE
add `HTTPHeaders.first(name:)`

### DIFF
--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -46,7 +46,7 @@ extension String.UTF8View {
     ///
     /// - Parameter bytes: The string constant in the form of a collection of `UInt8`
     /// - Returns: Whether the collection contains **EXACTLY** this array or no, but by ignoring case.
-    internal func compareCaseInsensitiveASCIIBytes(to: String.UTF8View ) -> Bool {
+    internal func compareCaseInsensitiveASCIIBytes(to: String.UTF8View) -> Bool {
         // fast path: we can get the underlying bytes of both
         let maybeMaybeResult = self.withContiguousStorageIfAvailable { lhsBuffer -> Bool? in
             to.withContiguousStorageIfAvailable { rhsBuffer in

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -38,7 +38,7 @@ extension String {
     }
 }
 
-extension Sequence where Self.Element == UInt8 {
+extension String.UTF8View {
     /// Compares the collection of `UInt8`s to a case insensitive collection.
     ///
     /// This collection could be get from applying the `UTF8View`

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -12,10 +12,68 @@
 //
 //===----------------------------------------------------------------------===//
 
-// MARK: HTTPMethod
+// MARK: HTTPHeaders
 
 public typealias HTTPHeaders = [String: String]
 public typealias HTTPMultiValueHeaders = [String: [String]]
+
+extension HTTPHeaders {
+    /// Retrieves the first value for a given header-field / dictionary-key (`name`) from the block.
+    /// This method uses case-insensitive comparisons.
+    ///
+    /// - Parameter name: The header field name whose first value should be retrieved.
+    /// - Returns: The first value for the header field name.
+    public func first(name: String) -> String? {
+        guard !self.isEmpty else {
+            return nil
+        }
+
+        return self.first { header in header.0.isEqualCaseInsensitiveASCIIBytes(to: name) }?.1
+    }
+}
+
+extension String {
+    internal func isEqualCaseInsensitiveASCIIBytes(to: String) -> Bool {
+        return self.utf8.compareCaseInsensitiveASCIIBytes(to: to.utf8)
+    }
+}
+
+extension Sequence where Self.Element == UInt8 {
+    /// Compares the collection of `UInt8`s to a case insensitive collection.
+    ///
+    /// This collection could be get from applying the `UTF8View`
+    ///   property on the string protocol.
+    ///
+    /// - Parameter bytes: The string constant in the form of a collection of `UInt8`
+    /// - Returns: Whether the collection contains **EXACTLY** this array or no, but by ignoring case.
+    internal func compareCaseInsensitiveASCIIBytes<T: Sequence>(to: T) -> Bool
+    where T.Element == UInt8 {
+        // fast path: we can get the underlying bytes of both
+        let maybeMaybeResult = self.withContiguousStorageIfAvailable { lhsBuffer -> Bool? in
+            to.withContiguousStorageIfAvailable { rhsBuffer in
+                if lhsBuffer.count != rhsBuffer.count {
+                    return false
+                }
+
+                for idx in 0 ..< lhsBuffer.count {
+                    // let's hope this gets vectorised ;)
+                    if lhsBuffer[idx] & 0xdf != rhsBuffer[idx] & 0xdf {
+                        return false
+                    }
+                }
+                return true
+            }
+        }
+
+        if let maybeResult = maybeMaybeResult, let result = maybeResult {
+            return result
+        } else {
+            return self.elementsEqual(to, by: {return ($0 & 0xdf) == ($1 & 0xdf)})
+        }
+    }
+}
+
+// MARK: HTTPMethod
 
 public struct HTTPMethod: RawRepresentable, Equatable {
     public var rawValue: String

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -34,7 +34,7 @@ extension HTTPHeaders {
 
 extension String {
     internal func isEqualCaseInsensitiveASCIIBytes(to: String) -> Bool {
-        return self.utf8.compareCaseInsensitiveASCIIBytes(to: to.utf8)
+        self.utf8.compareCaseInsensitiveASCIIBytes(to: to.utf8)
     }
 }
 
@@ -46,8 +46,7 @@ extension String.UTF8View {
     ///
     /// - Parameter bytes: The string constant in the form of a collection of `UInt8`
     /// - Returns: Whether the collection contains **EXACTLY** this array or no, but by ignoring case.
-    internal func compareCaseInsensitiveASCIIBytes<T: Sequence>(to: T) -> Bool
-    where T.Element == UInt8 {
+    internal func compareCaseInsensitiveASCIIBytes(to: String.UTF8View ) -> Bool {
         // fast path: we can get the underlying bytes of both
         let maybeMaybeResult = self.withContiguousStorageIfAvailable { lhsBuffer -> Bool? in
             to.withContiguousStorageIfAvailable { rhsBuffer in
@@ -57,7 +56,7 @@ extension String.UTF8View {
 
                 for idx in 0 ..< lhsBuffer.count {
                     // let's hope this gets vectorised ;)
-                    if lhsBuffer[idx] & 0xdf != rhsBuffer[idx] & 0xdf {
+                    if lhsBuffer[idx] & 0xDF != rhsBuffer[idx] & 0xDF {
                         return false
                     }
                 }
@@ -68,7 +67,7 @@ extension String.UTF8View {
         if let maybeResult = maybeMaybeResult, let result = maybeResult {
             return result
         } else {
-            return self.elementsEqual(to, by: {return ($0 & 0xdf) == ($1 & 0xdf)})
+            return self.elementsEqual(to, by: { ($0 & 0xDF) == ($1 & 0xDF) })
         }
     }
 }

--- a/Tests/AWSLambdaEventsTests/Utils/HTTPHeadersTests.swift
+++ b/Tests/AWSLambdaEventsTests/Utils/HTTPHeadersTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSLambdaEvents
+import XCTest
+
+class HTTPHeadersTests: XCTestCase {
+    func first() throws {
+        let headers: HTTPHeaders = [
+            ":method": "GET",
+            "foo": "bar",
+            "custom-key": "value-1,value-2"
+        ]
+
+        XCTAssertEqual(headers.first(name: ":method"), "GET")
+        XCTAssertEqual(headers.first(name: "Foo"), "bar")
+        XCTAssertEqual(headers.first(name: "custom-key"), "value-1,value-2")
+        XCTAssertNil(headers.first(name: "not-present"))
+    }
+}

--- a/Tests/AWSLambdaEventsTests/Utils/HTTPHeadersTests.swift
+++ b/Tests/AWSLambdaEventsTests/Utils/HTTPHeadersTests.swift
@@ -20,7 +20,7 @@ class HTTPHeadersTests: XCTestCase {
         let headers: HTTPHeaders = [
             ":method": "GET",
             "foo": "bar",
-            "custom-key": "value-1,value-2"
+            "custom-key": "value-1,value-2",
         ]
 
         XCTAssertEqual(headers.first(name: ":method"), "GET")


### PR DESCRIPTION
Adds a new method `first(name:)` to `HTTPHeaders` (aka just `[String: String]`).

### Motivation:

I first noticed absence of such a function when I was trying to get 2 different headers of a Github request.
Using capitalized header names as mentioned in Github docs, or lowercased names, both would fail.
(**EDIT:** To be clear, i think one header had a capitalized name and the other a lowercased name, which is just an inconsistency by Github in this case.)
That was when [I copy-pasted `swift-nio`'s `HTTPHeaders.first(name:)` function to the lambda target](https://github.com/vapor/penny-bot/commit/bf98089237fbbefe7c24b00802f98092a446a2b2), which fixed the issue.

I think this will be a generally useful function, as it's even available in NIO's implementation of `HTTPHeaders`.

### Modifications:

Copy-paste [NIO's implementation of `HTTPHeaders.first(name:)`](https://github.com/apple/swift-nio/blob/2ab733246c7989b1f569dcb3645f2de7a0232f20/Sources/NIOHTTP1/HTTPTypes.swift#L449).
Modify the comments to be correct about this project.
Declare the extension on `String.UTF8View` instead of `Sequence<UInt8>` as we don't need the generic extension unlike NIO.

**Update:** Copy-pasted the tests as well.

### Result:

Addition of a function to the public API `HTTPHeaders.first(name:)` (aka `Dictionary<String, String>.first(name:)`).
