### PR TITLE
add support for IAM authorizers

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -34,12 +34,17 @@ public struct APIGatewayV2Request: Codable {
 
             public let jwt: JWT?
 
-            /// `IAM` contains AWS IAM authorizer information for the request context.
-            public struct IAM: Codable, Sendable {
+            // `IAM` contains AWS IAM authorizer information for the request context.
+            public struct IAM: Codable {
+                public struct CognitoIdentity: Codable {
+                    public let amr: [String]?
+                    public let identityId: String?
+                    public let identityPoolId: String?
+                }
                 public let accessKey: String?
                 public let accountId: String?
                 public let callerId: String?
-                public let cognitoIdentity: String?
+                public let cognitoIdentity: CognitoIdentity?
                 public let principalOrgId: String?
                 public let userArn: String?
                 public let userId: String?
@@ -126,5 +131,7 @@ extension APIGatewayV2Request.Context: Sendable {}
 extension APIGatewayV2Request.Context.HTTP: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.JWT: Sendable {}
+extension APIGatewayV2Request.Context.Authorizer.IAM: Sendable {}
+extension APIGatewayV2Request.Context.Authorizer.IAM.CognitoIdentity: Sendable {}
 extension APIGatewayV2Response: Sendable {}
 #endif

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -41,6 +41,7 @@ public struct APIGatewayV2Request: Codable {
                     public let identityId: String?
                     public let identityPoolId: String?
                 }
+
                 public let accessKey: String?
                 public let accountId: String?
                 public let callerId: String?

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -31,6 +31,7 @@ public struct APIGatewayV2Request: Codable {
                 public let claims: [String: String]?
                 public let scopes: [String]?
             }
+
             public let jwt: JWT?
 
             /// `IAM` contains AWS IAM authorizer information for the request context.
@@ -43,6 +44,7 @@ public struct APIGatewayV2Request: Codable {
                 public let userArn: String?
                 public let userId: String?
             }
+
             public let iam: IAM?
         }
 

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -31,8 +31,19 @@ public struct APIGatewayV2Request: Codable {
                 public let claims: [String: String]?
                 public let scopes: [String]?
             }
+            public let jwt: JWT?
 
-            public let jwt: JWT
+            /// `IAM` contains AWS IAM authorizer information for the request context.
+            public struct IAM: Codable, Sendable {
+                public let accessKey: String?
+                public let accountId: String?
+                public let callerId: String?
+                public let cognitoIdentity: String?
+                public let principalOrgId: String?
+                public let userArn: String?
+                public let userId: String?
+            }
+            public let iam: IAM?
         }
 
         public let accountId: String

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 class APIGatewayV2IAMTests: XCTestCase {
-    static let exampleGetEventBody = """
+    static let getEventWithIAM = """
     {
         "version": "2.0",
         "routeKey": "$default",
@@ -68,18 +68,92 @@ class APIGatewayV2IAMTests: XCTestCase {
     }
     """
 
+    static let getEventWithIAMAndCognito = """
+    {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/hello",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "authorization": "AWS4-HMAC-SHA256 Credential=ASIA-redacted/us-east-1/execute-api/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=289b5fcef3d1156f019cc1140cb5565cc052880a5a0d5586c753e3e3c75556f9",
+            "content-length": "0",
+            "host": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "user-agent": "curl/8.4.0",
+            "x-amz-date": "20231214T203121Z",
+            "x-amz-security-token": "IQoJb3JpZ2luX2VjEO3//////////-redacted",
+            "x-amzn-trace-id": "Root=1-657b6619-3222de40051925dd66e1fd72",
+            "x-forwarded-for": "191.95.150.52",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "012345678912",
+            "apiId": "74bxj8iqjc",
+            "authorizer": {
+                "iam": {
+                    "accessKey": "ASIA-redacted",
+                    "accountId": "012345678912",
+                    "callerId": "AROA-redacted:CognitoIdentityCredentials",
+                    "cognitoIdentity": {
+                        "amr": [
+                            "authenticated",
+                            "cognito-idp.us-east-1.amazonaws.com/us-east-1_ABCD",
+                            "cognito-idp.us-east-1.amazonaws.com/us-east-1_ABCD:CognitoSignIn:04611e3d--redacted"
+                        ],
+                        "identityId": "us-east-1:68bc0ecd-9d5e--redacted",
+                        "identityPoolId": "us-east-1:e8b526df--redacted"
+                    },
+                    "principalOrgId": "aws:PrincipalOrgID",
+                    "userArn": "arn:aws:sts::012345678912:assumed-role/authRole/CognitoIdentityCredentials",
+                    "userId": "AROA-redacted:CognitoIdentityCredentials"
+                }
+            },
+            "domainName": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "74bxj8iqjc",
+            "http": {
+                "method": "GET",
+                "path": "/liveness",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "191.95.150.52",
+                "userAgent": "curl/8.4.0"
+            },
+            "requestId": "P8zkDiQ8oAMEJsQ=",
+            "routeKey": "$default",
+            "stage": "$default",
+            "time": "14/Dec/2023:20:31:21 +0000",
+            "timeEpoch": 1702585881671
+        },
+        "isBase64Encoded": false
+    }
+    """
     // MARK: - Request -
 
     // MARK: Decoding
 
-    func testRequestDecodingExampleGetRequest() {
-        let data = APIGatewayV2IAMTests.exampleGetEventBody.data(using: .utf8)!
+    func testRequestDecodingGetRequestWithIAM() {
+        let data = APIGatewayV2IAMTests.getEventWithIAM.data(using: .utf8)!
         var req: APIGatewayV2Request?
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayV2Request.self, from: data))
 
         XCTAssertEqual(req?.rawPath, "/hello")
         XCTAssertEqual(req?.context.authorizer?.iam?.accessKey, "ASIA-redacted")
         XCTAssertEqual(req?.context.authorizer?.iam?.accountId, "012345678912")
+        XCTAssertNil(req?.body)
+    }
+    func testRequestDecodingGetRequestWithIAMWithCognito() {
+        let data = APIGatewayV2IAMTests.getEventWithIAMAndCognito.data(using: .utf8)!
+        var req: APIGatewayV2Request?
+        XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayV2Request.self, from: data))
+
+        XCTAssertEqual(req?.rawPath, "/hello")
+        XCTAssertEqual(req?.context.authorizer?.iam?.accessKey, "ASIA-redacted")
+        XCTAssertEqual(req?.context.authorizer?.iam?.accountId, "012345678912")
+
+        // test the cognito identity part
+        XCTAssertEqual(req?.context.authorizer?.iam?.cognitoIdentity?.identityId, "us-east-1:68bc0ecd-9d5e--redacted")
+        XCTAssertEqual(req?.context.authorizer?.iam?.cognitoIdentity?.amr?.count, 3)
+
         XCTAssertNil(req?.body)
     }
 }

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import AWSLambdaEvents
+import XCTest
+
+class APIGatewayV2IAMTests: XCTestCase {
+    static let exampleGetEventBody = """
+    {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/hello",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "authorization": "AWS4-HMAC-SHA256 Credential=ASIA-redacted/us-east-1/execute-api/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=289b5fcef3d1156f019cc1140cb5565cc052880a5a0d5586c753e3e3c75556f9",
+            "content-length": "0",
+            "host": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "user-agent": "curl/8.4.0",
+            "x-amz-date": "20231214T203121Z",
+            "x-amz-security-token": "IQoJb3JpZ2luX2VjEO3//////////-redacted",
+            "x-amzn-trace-id": "Root=1-657b6619-3222de40051925dd66e1fd72",
+            "x-forwarded-for": "191.95.150.52",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "012345678912",
+            "apiId": "74bxj8iqjc",
+            "authorizer": {
+                "iam": {
+                    "accessKey": "ASIA-redacted",
+                    "accountId": "012345678912",
+                    "callerId": "AIDA-redacted",
+                    "cognitoIdentity": null,
+                    "principalOrgId": "aws:PrincipalOrgID",
+                    "userArn": "arn:aws:iam::012345678912:user/sst",
+                    "userId": "AIDA-redacted"
+                }
+            },
+            "domainName": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "74bxj8iqjc",
+            "http": {
+                "method": "GET",
+                "path": "/liveness",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "191.95.150.52",
+                "userAgent": "curl/8.4.0"
+            },
+            "requestId": "P8zkDiQ8oAMEJsQ=",
+            "routeKey": "$default",
+            "stage": "$default",
+            "time": "14/Dec/2023:20:31:21 +0000",
+            "timeEpoch": 1702585881671
+        },
+        "isBase64Encoded": false
+    }
+    """
+
+    // MARK: - Request -
+
+    // MARK: Decoding
+
+    func testRequestDecodingExampleGetRequest() {
+        let data = APIGatewayV2IAMTests.exampleGetEventBody.data(using: .utf8)!
+        var req: APIGatewayV2Request?
+        XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayV2Request.self, from: data))
+
+        XCTAssertEqual(req?.rawPath, "/hello")
+        XCTAssertEqual(req?.context.authorizer?.iam?.accessKey, "ASIA-redacted")
+        XCTAssertEqual(req?.context.authorizer?.iam?.accountId, "012345678912")
+        XCTAssertNil(req?.body)
+    }
+}

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2IAMTests.swift
@@ -127,6 +127,7 @@ class APIGatewayV2IAMTests: XCTestCase {
         "isBase64Encoded": false
     }
     """
+
     // MARK: - Request -
 
     // MARK: Decoding
@@ -141,6 +142,7 @@ class APIGatewayV2IAMTests: XCTestCase {
         XCTAssertEqual(req?.context.authorizer?.iam?.accountId, "012345678912")
         XCTAssertNil(req?.body)
     }
+
     func testRequestDecodingGetRequestWithIAMWithCognito() {
         let data = APIGatewayV2IAMTests.getEventWithIAMAndCognito.data(using: .utf8)!
         var req: APIGatewayV2Request?

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
@@ -86,6 +86,8 @@ class APIGatewayV2Tests: XCTestCase {
         XCTAssertEqual(req?.queryStringParameters?.count, 1)
         XCTAssertEqual(req?.rawQueryString, "foo=bar")
         XCTAssertEqual(req?.headers.count, 8)
+        XCTAssertEqual(req?.context.authorizer?.jwt?.claims?["aud"], "customers")
+
         XCTAssertNil(req?.body)
     }
 }

--- a/docker/docker-compose.al2.56.yaml
+++ b/docker/docker-compose.al2.56.yaml
@@ -8,6 +8,9 @@ services:
       args:
         swift_version: "5.6"
 
+  soundness:
+    image: swift-aws-lambda-events:al2-5.6
+
   test:
     image: swift-aws-lambda-events:al2-5.6
 

--- a/docker/docker-compose.al2.57.yaml
+++ b/docker/docker-compose.al2.57.yaml
@@ -8,6 +8,9 @@ services:
       args:
         swift_version: "5.7"
 
+  soundness:
+    image: swift-aws-lambda-events:al2-5.7
+
   test:
     image: swift-aws-lambda-events:al2-5.7
 

--- a/docker/docker-compose.al2.58.yaml
+++ b/docker/docker-compose.al2.58.yaml
@@ -8,6 +8,9 @@ services:
       args:
         swift_version: "5.8"
 
+  soundness:
+    image: swift-aws-lambda-events:al2-5.8
+
   test:
     image: swift-aws-lambda-events:al2-5.8
 

--- a/docker/docker-compose.al2.59.yaml
+++ b/docker/docker-compose.al2.59.yaml
@@ -8,6 +8,9 @@ services:
       args:
         base_image: "swiftlang/swift:nightly-5.9-amazonlinux2"
 
+  soundness:
+    image: swift-aws-lambda-events:al2-5.9
+
   test:
     image: swift-aws-lambda-events:al2-5.9
 

--- a/docker/docker-compose.al2.main.yaml
+++ b/docker/docker-compose.al2.main.yaml
@@ -8,6 +8,9 @@ services:
       args:
         base_image: "swiftlang/swift:nightly-main-amazonlinux2"
 
+  soundness:
+    image: swift-aws-lambda-events:al2-main
+
   test:
     image: swift-aws-lambda-events:al2-main
 


### PR DESCRIPTION
add support for `iam` authorizer in addition to JWT
See https://github.com/swift-server/swift-aws-lambda-events/issues/40

### Motivation:

I need to deploy Swift Lambda function protected by IAM

### Modifications:

- Add an optional `iam` element inside `requestContext` 
- mark `jwt` element as optional (this is a breaking change for existing application consuming this property) 

### Result:

We can use API Gateway with IAM authentication.
Existing code using `jwt` authentication will need to handle the optional (but marking it as non optional was incorrect) 


