### PR TITLE
Add support for AWS Lambda Authorizers

### DIFF
--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// `LambdaAuthorizerContext` contains authorizer informations passed to a Lambda function authorizer
+public typealias LambdaAuthorizerContext = [String:String]
+
 /// `APIGatewayV2Request` contains data coming from the new HTTP API Gateway.
 public struct APIGatewayV2Request: Codable {
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
@@ -52,6 +55,8 @@ public struct APIGatewayV2Request: Codable {
             }
 
             public let iam: IAM?
+            
+            public let lambda: LambdaAuthorizerContext?
         }
 
         public let accountId: String
@@ -126,6 +131,11 @@ public struct APIGatewayV2Response: Codable {
     }
 }
 
+public struct APIGatewayLambdaAuthorizerResponse: Decodable {
+    public let isAuthorized: Bool
+    public let context: LambdaAuthorizerContext?
+}
+
 #if swift(>=5.6)
 extension APIGatewayV2Request: Sendable {}
 extension APIGatewayV2Request.Context: Sendable {}
@@ -134,5 +144,7 @@ extension APIGatewayV2Request.Context.Authorizer: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.JWT: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.IAM: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.IAM.CognitoIdentity: Sendable {}
+extension LambdaAuthorizerContext: Sendable {}
 extension APIGatewayV2Response: Sendable {}
+extension APIGatewayLambdaAuthorizerResponse: Sendable {}
 #endif

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -12,9 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// `LambdaAuthorizerContext` contains authorizer informations passed to a Lambda function authorizer
-public typealias LambdaAuthorizerContext = [String:String]
-
 /// `APIGatewayV2Request` contains data coming from the new HTTP API Gateway.
 public struct APIGatewayV2Request: Codable {
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
@@ -55,7 +52,7 @@ public struct APIGatewayV2Request: Codable {
             }
 
             public let iam: IAM?
-            
+
             public let lambda: LambdaAuthorizerContext?
         }
 
@@ -131,11 +128,6 @@ public struct APIGatewayV2Response: Codable {
     }
 }
 
-public struct APIGatewayLambdaAuthorizerResponse: Decodable {
-    public let isAuthorized: Bool
-    public let context: LambdaAuthorizerContext?
-}
-
 #if swift(>=5.6)
 extension APIGatewayV2Request: Sendable {}
 extension APIGatewayV2Request.Context: Sendable {}
@@ -144,7 +136,5 @@ extension APIGatewayV2Request.Context.Authorizer: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.JWT: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.IAM: Sendable {}
 extension APIGatewayV2Request.Context.Authorizer.IAM.CognitoIdentity: Sendable {}
-extension LambdaAuthorizerContext: Sendable {}
 extension APIGatewayV2Response: Sendable {}
-extension APIGatewayLambdaAuthorizerResponse: Sendable {}
 #endif

--- a/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
+++ b/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
@@ -88,6 +88,7 @@ public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
                 self.effect = effect
                 self.resource = resource
             }
+
             public enum CodingKeys: String, CodingKey {
                 case action = "Action"
                 case effect = "Effect"
@@ -101,7 +102,7 @@ public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
             self.version = version
             self.statement = statement
         }
-        
+
         public enum CodingKeys: String, CodingKey {
             case version = "Version"
             case statement = "Statement"

--- a/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
+++ b/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// `LambdaAuthorizerContext` contains authorizer informations passed to a Lambda function authorizer
+public typealias LambdaAuthorizerContext = [String: String]
+
+public struct APIGatewayLambdaAuthorizerRequest: Codable {
+    let version: String
+    let type: String
+    let routeArn: String?
+    let identitySource: [String]
+    let routeKey: String
+    let rawPath: String
+    let rawQueryString: String
+    let headers: [String: String]
+
+    /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
+    public struct Context: Codable {
+        public struct HTTP: Codable {
+            public let method: HTTPMethod
+            public let path: String
+            public let `protocol`: String
+            public let sourceIp: String
+            public let userAgent: String
+        }
+
+        public let accountId: String
+        public let apiId: String
+        public let domainName: String
+        public let domainPrefix: String
+        public let stage: String
+        public let requestId: String
+
+        public let http: HTTP
+
+        /// The request time in format: 23/Apr/2020:11:08:18 +0000
+        public let time: String
+        public let timeEpoch: UInt64
+    }
+
+    let requestContext: Context?
+}
+
+public struct APIGatewayLambdaAuthorizerResponse: Codable {
+    public let isAuthorized: Bool
+    public let context: LambdaAuthorizerContext?
+}
+
+#if swift(>=5.6)
+extension LambdaAuthorizerContext: Sendable {}
+extension APIGatewayLambdaAuthorizerRequest: Sendable {}
+extension APIGatewayLambdaAuthorizerRequest.Context: Sendable {}
+extension APIGatewayLambdaAuthorizerRequest.Context.HTTP: Sendable {}
+extension APIGatewayLambdaAuthorizerResponse: Sendable {}
+#endif

--- a/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
+++ b/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
@@ -88,6 +88,11 @@ public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
                 self.effect = effect
                 self.resource = resource
             }
+            public enum CodingKeys: String, CodingKey {
+                case action = "Action"
+                case effect = "Effect"
+                case resource = "Resource"
+            }
         }
 
         public let statement: [Statement]
@@ -95,6 +100,11 @@ public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
         public init(version: String = "2012-10-17", statement: [Statement]) {
             self.version = version
             self.statement = statement
+        }
+        
+        public enum CodingKeys: String, CodingKey {
+            case version = "Version"
+            case statement = "Statement"
         }
     }
 

--- a/Tests/AWSLambdaEventsTests/APIGatewayLambdaAuthorizerTest.swift
+++ b/Tests/AWSLambdaEventsTests/APIGatewayLambdaAuthorizerTest.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import AWSLambdaEvents
+import XCTest
+
+class APIGatewayLambdaAuthorizerTests: XCTestCase {
+    static let getEventWithLambdaAuthorizer = """
+    {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/hello",
+        "rawQueryString": "",
+        "headers": {
+            "accept": "*/*",
+            "authorization": "AWS4-HMAC-SHA256 Credential=ASIA-redacted/us-east-1/execute-api/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=289b5fcef3d1156f019cc1140cb5565cc052880a5a0d5586c753e3e3c75556f9",
+            "content-length": "0",
+            "host": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "user-agent": "curl/8.4.0",
+            "x-amz-date": "20231214T203121Z",
+            "x-amz-security-token": "IQoJb3JpZ2luX2VjEO3//////////-redacted",
+            "x-amzn-trace-id": "Root=1-657b6619-3222de40051925dd66e1fd72",
+            "x-forwarded-for": "191.95.150.52",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https"
+        },
+        "requestContext": {
+            "accountId": "012345678912",
+            "apiId": "74bxj8iqjc",
+            "authorizer": {
+                "lambda": {
+                    "abc1": "xyz1",
+                    "abc2": "xyz2",
+                }
+            },
+            "domainName": "74bxj8iqjc.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "74bxj8iqjc",
+            "http": {
+                "method": "GET",
+                "path": "/liveness",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "191.95.150.52",
+                "userAgent": "curl/8.4.0"
+            },
+            "requestId": "P8zkDiQ8oAMEJsQ=",
+            "routeKey": "$default",
+            "stage": "$default",
+            "time": "14/Dec/2023:20:31:21 +0000",
+            "timeEpoch": 1702585881671
+        },
+        "isBase64Encoded": false
+    }
+    """
+
+    static let lambdaAuthorizerResponse = """
+    {
+      "isAuthorized": true,
+      "context": {
+        "exampleKey": "exampleValue"
+      }
+    }
+    """
+    
+    // MARK: - Request -
+
+    // MARK: Decoding
+
+    func testRequestDecodingGetRequestWithLambdaAuthorizer() {
+        let data = APIGatewayLambdaAuthorizerTests.getEventWithLambdaAuthorizer.data(using: .utf8)!
+        var req: APIGatewayV2Request?
+        XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayV2Request.self, from: data))
+
+        XCTAssertEqual(req?.rawPath, "/hello")
+        XCTAssertEqual(req?.context.authorizer?.lambda?.count, 2)
+        XCTAssertEqual(req?.context.authorizer?.lambda?["abc1"], "xyz1")
+        XCTAssertEqual(req?.context.authorizer?.lambda?["abc2"], "xyz2")
+        XCTAssertNil(req?.body)
+    }
+
+    func testDecodingLambdaAuthorizerResponse() {
+        let data = APIGatewayLambdaAuthorizerTests.lambdaAuthorizerResponse.data(using: .utf8)!
+        var response: APIGatewayLambdaAuthorizerResponse?
+        XCTAssertNoThrow(response = try JSONDecoder().decode(APIGatewayLambdaAuthorizerResponse.self, from: data))
+
+        XCTAssertEqual(response?.isAuthorized, true)
+        XCTAssertEqual(response?.context?.count, 1)
+        XCTAssertEqual(response?.context?["exampleKey"], "exampleValue")
+    }
+}


### PR DESCRIPTION
Add support for Lambda Authorizers as requested by issue https://github.com/swift-server/swift-aws-lambda-events/issues/39

### Motivation:

Lambda authorizers are Lambda functions called by Amazon API Gateway to delegate authorization decisions. There are used both by the Rest API and the HTTP API gateway (aka APIGateway and APIGatewayv2) 
https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html

### Modifications:

This changes introduce three modifications.

The first modification allows Swift developer to write Lambda functions protected by a Lambda authorizer function.

1. support the `lambda` object under `authorizer` in `APIGatewayV2.swift`. This allows Lambda function behind a Lambda Authorizer to gather the identity and authorization data shared by the Lambda authorizer function. The `lambda` object comes as an alternative to the existing `jwt` and `iam` objects.

The other additions allow Swift developers to write Lambda authorizer functions in the Swift programming language. 

2. create a new struct `APIGatewayLambdaAuthorizerRequest` to represent the payload sent to a Lambda authorizer function
3. create a new struct `APIGatewayLambdaAuthorizerSimpleResponse` to represent the simple response from a Lambda authorizer function
4. create a new struct `APIGatewayLambdaAuthorizerPolicyResponse` to represent the IAM policy document response from a Lambda authorizer function.

[The documentation has the details about Lambda authorizer response types](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html#http-api-lambda-authorizer.payload-format-response). 

This change supports the payload format v2.0 only. I didn't implement payload v1.0 because it is considered as legacy and not recommended to use for new projects.

### Results:

- Developers can write Lambda functions that are protected by a Lambda authorizer function (written in any language) 

- Developers can write Lambda authorizer function in Swift.

This change has been tested end-to-end on a sample project I wrote and validated by another developer on his own project (@georgepreece) 
