### PR TITLE
Update EventBridgeEvent visibility

### DIFF
--- a/Sources/AWSLambdaEvents/Cloudwatch.swift
+++ b/Sources/AWSLambdaEvents/Cloudwatch.swift
@@ -19,7 +19,7 @@ import struct Foundation.Date
 #endif
 
 /// EventBridge has the same events/notification types as CloudWatch
-typealias EventBridgeEvent = CloudwatchEvent
+public typealias EventBridgeEvent = CloudwatchEvent
 
 public protocol CloudwatchDetail: Decodable {
     static var name: String { get }


### PR DESCRIPTION
Hi there,

I assume you meant EventBridgeEvent to be consumable by client libraries. This PR just changes the visibility of the typealias from internal to public.