### PR TITLE
Use Swift HTTP types package for status and method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
     ],
     targets: [
-        .target(name: "AWSLambdaEvents", dependencies: []),
+        .target(name: "AWSLambdaEvents", dependencies: [.product(name: "HTTPTypes", package: "swift-http-types")]),
         .testTarget(name: "AWSLambdaEventsTests", dependencies: ["AWSLambdaEvents"]),
     ]
 )

--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 import class Foundation.JSONEncoder
 
 // https://github.com/aws/aws-lambda-go/blob/master/events/alb.go
@@ -22,7 +24,7 @@ public struct ALBTargetGroupRequest: Codable {
         public let elb: ELBContext
     }
 
-    public let httpMethod: HTTPMethod
+    public let httpMethod: HTTPRequest.Method
     public let path: String
     public let queryStringParameters: [String: String]
 
@@ -50,7 +52,7 @@ public struct ALBTargetGroupRequest: Codable {
 }
 
 public struct ALBTargetGroupResponse: Codable {
-    public var statusCode: HTTPResponseStatus
+    public var statusCode: HTTPResponse.Status
     public var statusDescription: String?
     public var headers: HTTPHeaders?
     public var multiValueHeaders: HTTPMultiValueHeaders?
@@ -58,7 +60,7 @@ public struct ALBTargetGroupResponse: Codable {
     public var isBase64Encoded: Bool
 
     public init(
-        statusCode: HTTPResponseStatus,
+        statusCode: HTTPResponse.Status,
         statusDescription: String? = nil,
         headers: HTTPHeaders? = nil,
         multiValueHeaders: HTTPMultiValueHeaders? = nil,

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -12,12 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 /// `APIGatewayV2Request` contains data coming from the new HTTP API Gateway.
 public struct APIGatewayV2Request: Codable {
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
     public struct Context: Codable {
         public struct HTTP: Codable {
-            public let method: HTTPMethod
+            public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
             public let sourceIp: String
@@ -125,14 +127,14 @@ public struct APIGatewayV2Request: Codable {
 }
 
 public struct APIGatewayV2Response: Codable {
-    public var statusCode: HTTPResponseStatus
+    public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var body: String?
     public var isBase64Encoded: Bool?
     public var cookies: [String]?
 
     public init(
-        statusCode: HTTPResponseStatus,
+        statusCode: HTTPResponse.Status,
         headers: HTTPHeaders? = nil,
         body: String? = nil,
         isBase64Encoded: Bool? = nil,

--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 import class Foundation.JSONEncoder
 
 // https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html
@@ -56,7 +58,7 @@ public struct APIGatewayRequest: Codable {
 
     public let resource: String
     public let path: String
-    public let httpMethod: HTTPMethod
+    public let httpMethod: HTTPRequest.Method
 
     public let queryStringParameters: [String: String]?
     public let multiValueQueryStringParameters: [String: [String]]?
@@ -73,14 +75,14 @@ public struct APIGatewayRequest: Codable {
 // MARK: - Response -
 
 public struct APIGatewayResponse: Codable {
-    public var statusCode: HTTPResponseStatus
+    public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var multiValueHeaders: HTTPMultiValueHeaders?
     public var body: String?
     public var isBase64Encoded: Bool?
 
     public init(
-        statusCode: HTTPResponseStatus,
+        statusCode: HTTPResponse.Status,
         headers: HTTPHeaders? = nil,
         multiValueHeaders: HTTPMultiValueHeaders? = nil,
         body: String? = nil,

--- a/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
+++ b/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 /// `LambdaAuthorizerContext` contains authorizer informations passed to a Lambda function authorizer
 public typealias LambdaAuthorizerContext = [String: String]
 
@@ -29,7 +31,7 @@ public struct APIGatewayLambdaAuthorizerRequest: Codable {
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
     public struct Context: Codable {
         public struct HTTP: Codable {
-            public let method: HTTPMethod
+            public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
             public let sourceIp: String

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 // https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
 public struct AppSyncEvent: Decodable {
     public let arguments: [String: ArgumentValue]

--- a/Sources/AWSLambdaEvents/FunctionURL.swift
+++ b/Sources/AWSLambdaEvents/FunctionURL.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import HTTPTypes
 
 import class Foundation.JSONEncoder
 
@@ -37,7 +38,7 @@ public struct FunctionURLRequest: Codable {
         }
 
         public struct HTTP: Codable {
-            public let method: HTTPMethod
+            public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
             public let sourceIp: String
@@ -81,14 +82,14 @@ public struct FunctionURLRequest: Codable {
 // MARK: - Response -
 
 public struct FunctionURLResponse: Codable {
-    public var statusCode: HTTPResponseStatus
+    public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var body: String?
     public let cookies: [String]?
     public var isBase64Encoded: Bool?
 
     public init(
-        statusCode: HTTPResponseStatus,
+        statusCode: HTTPResponse.Status,
         headers: HTTPHeaders? = nil,
         body: String? = nil,
         cookies: [String]? = nil,

--- a/Sources/AWSLambdaEvents/LambdaGatewayProxyEvent.swift
+++ b/Sources/AWSLambdaEvents/LambdaGatewayProxyEvent.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import HTTPTypes
+
 /// LambdaGatewayProxyEvent contains data coming from the new HTTP API Gateway Proxy
 public struct LambdaGatewayProxyEvent: Decodable {
     public struct RequestContext: Decodable {
@@ -28,7 +30,7 @@ public struct LambdaGatewayProxyEvent: Decodable {
         public let stage: String
         public let requestID: String
 
-        public let httpMethod: HTTPMethod
+        public let httpMethod: HTTPRequest.Method
         public let authorizer: Authorizer?
 
         public let resourcePath: String?

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -86,7 +86,6 @@ extension HTTPResponse.Status: Codable {
     }
 }
 
-
 extension HTTPRequest.Method: Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Sources/AWSLambdaEvents/Utils/HTTP.swift
+++ b/Sources/AWSLambdaEvents/Utils/HTTP.swift
@@ -14,6 +14,8 @@
 
 // MARK: HTTPHeaders
 
+import HTTPTypes
+
 public typealias HTTPHeaders = [String: String]
 public typealias HTTPMultiValueHeaders = [String: [String]]
 
@@ -72,178 +74,32 @@ extension String.UTF8View {
     }
 }
 
-// MARK: HTTPMethod
-
-public struct HTTPMethod: RawRepresentable, Equatable {
-    public var rawValue: String
-
-    public init?(rawValue: String) {
-        guard rawValue.isValidHTTPToken else {
-            return nil
-        }
-        self.rawValue = rawValue
+extension HTTPResponse.Status: Codable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.code)
     }
 
-    public static var GET: HTTPMethod { HTTPMethod(rawValue: "GET")! }
-    public static var POST: HTTPMethod { HTTPMethod(rawValue: "POST")! }
-    public static var PUT: HTTPMethod { HTTPMethod(rawValue: "PUT")! }
-    public static var PATCH: HTTPMethod { HTTPMethod(rawValue: "PATCH")! }
-    public static var DELETE: HTTPMethod { HTTPMethod(rawValue: "DELETE")! }
-    public static var OPTIONS: HTTPMethod { HTTPMethod(rawValue: "OPTIONS")! }
-    public static var HEAD: HTTPMethod { HTTPMethod(rawValue: "HEAD")! }
-
-    public static func RAW(value: String) -> HTTPMethod? { HTTPMethod(rawValue: value) }
+    public init(from decoder: any Decoder) throws {
+        let code = try decoder.singleValueContainer().decode(Int.self)
+        self.init(code: code)
+    }
 }
 
-extension HTTPMethod: Codable {
-    public init(from decoder: Decoder) throws {
+
+extension HTTPRequest.Method: Codable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let rawMethod = try container.decode(String.self)
-
-        guard let method = HTTPMethod(rawValue: rawMethod) else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: #"Method "\#(rawMethod)" does not conform to allowed http method syntax defined in RFC 7230 Section 3.2.6"#
-            )
+        guard let method = HTTPRequest.Method(rawMethod) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "\"\(rawMethod)\" is not a valid method")
         }
 
         self = method
     }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(self.rawValue)
-    }
 }
-
-// MARK: HTTPResponseStatus
-
-public struct HTTPResponseStatus {
-    public let code: UInt
-    public let reasonPhrase: String?
-
-    public init(code: UInt, reasonPhrase: String? = nil) {
-        self.code = code
-        self.reasonPhrase = reasonPhrase
-    }
-
-    public static var `continue`: HTTPResponseStatus { HTTPResponseStatus(code: 100) }
-    public static var switchingProtocols: HTTPResponseStatus { HTTPResponseStatus(code: 101) }
-    public static var processing: HTTPResponseStatus { HTTPResponseStatus(code: 102) }
-    public static var earlyHints: HTTPResponseStatus { HTTPResponseStatus(code: 103) }
-
-    public static var ok: HTTPResponseStatus { HTTPResponseStatus(code: 200) }
-    public static var created: HTTPResponseStatus { HTTPResponseStatus(code: 201) }
-    public static var accepted: HTTPResponseStatus { HTTPResponseStatus(code: 202) }
-    public static var nonAuthoritativeInformation: HTTPResponseStatus { HTTPResponseStatus(code: 203) }
-    public static var noContent: HTTPResponseStatus { HTTPResponseStatus(code: 204) }
-    public static var resetContent: HTTPResponseStatus { HTTPResponseStatus(code: 205) }
-    public static var partialContent: HTTPResponseStatus { HTTPResponseStatus(code: 206) }
-    public static var multiStatus: HTTPResponseStatus { HTTPResponseStatus(code: 207) }
-    public static var alreadyReported: HTTPResponseStatus { HTTPResponseStatus(code: 208) }
-    public static var imUsed: HTTPResponseStatus { HTTPResponseStatus(code: 226) }
-
-    public static var multipleChoices: HTTPResponseStatus { HTTPResponseStatus(code: 300) }
-    public static var movedPermanently: HTTPResponseStatus { HTTPResponseStatus(code: 301) }
-    public static var found: HTTPResponseStatus { HTTPResponseStatus(code: 302) }
-    public static var seeOther: HTTPResponseStatus { HTTPResponseStatus(code: 303) }
-    public static var notModified: HTTPResponseStatus { HTTPResponseStatus(code: 304) }
-    public static var useProxy: HTTPResponseStatus { HTTPResponseStatus(code: 305) }
-    public static var temporaryRedirect: HTTPResponseStatus { HTTPResponseStatus(code: 307) }
-    public static var permanentRedirect: HTTPResponseStatus { HTTPResponseStatus(code: 308) }
-
-    public static var badRequest: HTTPResponseStatus { HTTPResponseStatus(code: 400) }
-    public static var unauthorized: HTTPResponseStatus { HTTPResponseStatus(code: 401) }
-    public static var paymentRequired: HTTPResponseStatus { HTTPResponseStatus(code: 402) }
-    public static var forbidden: HTTPResponseStatus { HTTPResponseStatus(code: 403) }
-    public static var notFound: HTTPResponseStatus { HTTPResponseStatus(code: 404) }
-    public static var methodNotAllowed: HTTPResponseStatus { HTTPResponseStatus(code: 405) }
-    public static var notAcceptable: HTTPResponseStatus { HTTPResponseStatus(code: 406) }
-    public static var proxyAuthenticationRequired: HTTPResponseStatus { HTTPResponseStatus(code: 407) }
-    public static var requestTimeout: HTTPResponseStatus { HTTPResponseStatus(code: 408) }
-    public static var conflict: HTTPResponseStatus { HTTPResponseStatus(code: 409) }
-    public static var gone: HTTPResponseStatus { HTTPResponseStatus(code: 410) }
-    public static var lengthRequired: HTTPResponseStatus { HTTPResponseStatus(code: 411) }
-    public static var preconditionFailed: HTTPResponseStatus { HTTPResponseStatus(code: 412) }
-    public static var payloadTooLarge: HTTPResponseStatus { HTTPResponseStatus(code: 413) }
-    public static var uriTooLong: HTTPResponseStatus { HTTPResponseStatus(code: 414) }
-    public static var unsupportedMediaType: HTTPResponseStatus { HTTPResponseStatus(code: 415) }
-    public static var rangeNotSatisfiable: HTTPResponseStatus { HTTPResponseStatus(code: 416) }
-    public static var expectationFailed: HTTPResponseStatus { HTTPResponseStatus(code: 417) }
-    public static var imATeapot: HTTPResponseStatus { HTTPResponseStatus(code: 418) }
-    public static var misdirectedRequest: HTTPResponseStatus { HTTPResponseStatus(code: 421) }
-    public static var unprocessableEntity: HTTPResponseStatus { HTTPResponseStatus(code: 422) }
-    public static var locked: HTTPResponseStatus { HTTPResponseStatus(code: 423) }
-    public static var failedDependency: HTTPResponseStatus { HTTPResponseStatus(code: 424) }
-    public static var upgradeRequired: HTTPResponseStatus { HTTPResponseStatus(code: 426) }
-    public static var preconditionRequired: HTTPResponseStatus { HTTPResponseStatus(code: 428) }
-    public static var tooManyRequests: HTTPResponseStatus { HTTPResponseStatus(code: 429) }
-    public static var requestHeaderFieldsTooLarge: HTTPResponseStatus { HTTPResponseStatus(code: 431) }
-    public static var unavailableForLegalReasons: HTTPResponseStatus { HTTPResponseStatus(code: 451) }
-
-    public static var internalServerError: HTTPResponseStatus { HTTPResponseStatus(code: 500) }
-    public static var notImplemented: HTTPResponseStatus { HTTPResponseStatus(code: 501) }
-    public static var badGateway: HTTPResponseStatus { HTTPResponseStatus(code: 502) }
-    public static var serviceUnavailable: HTTPResponseStatus { HTTPResponseStatus(code: 503) }
-    public static var gatewayTimeout: HTTPResponseStatus { HTTPResponseStatus(code: 504) }
-    public static var httpVersionNotSupported: HTTPResponseStatus { HTTPResponseStatus(code: 505) }
-    public static var variantAlsoNegotiates: HTTPResponseStatus { HTTPResponseStatus(code: 506) }
-    public static var insufficientStorage: HTTPResponseStatus { HTTPResponseStatus(code: 507) }
-    public static var loopDetected: HTTPResponseStatus { HTTPResponseStatus(code: 508) }
-    public static var notExtended: HTTPResponseStatus { HTTPResponseStatus(code: 510) }
-    public static var networkAuthenticationRequired: HTTPResponseStatus { HTTPResponseStatus(code: 511) }
-}
-
-extension HTTPResponseStatus: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.code == rhs.code
-    }
-}
-
-extension HTTPResponseStatus: Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.code = try container.decode(UInt.self)
-        self.reasonPhrase = nil
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(self.code)
-    }
-}
-
-extension String {
-    internal var isValidHTTPToken: Bool {
-        self.utf8.allSatisfy { char -> Bool in
-            switch char {
-            case UInt8(ascii: "a") ... UInt8(ascii: "z"),
-                 UInt8(ascii: "A") ... UInt8(ascii: "Z"),
-                 UInt8(ascii: "0") ... UInt8(ascii: "9"),
-                 UInt8(ascii: "!"),
-                 UInt8(ascii: "#"),
-                 UInt8(ascii: "$"),
-                 UInt8(ascii: "%"),
-                 UInt8(ascii: "&"),
-                 UInt8(ascii: "'"),
-                 UInt8(ascii: "*"),
-                 UInt8(ascii: "+"),
-                 UInt8(ascii: "-"),
-                 UInt8(ascii: "."),
-                 UInt8(ascii: "^"),
-                 UInt8(ascii: "_"),
-                 UInt8(ascii: "`"),
-                 UInt8(ascii: "|"),
-                 UInt8(ascii: "~"):
-                return true
-            default:
-                return false
-            }
-        }
-    }
-}
-
-#if swift(>=5.6)
-extension HTTPMethod: Sendable {}
-extension HTTPResponseStatus: Sendable {}
-#endif

--- a/Tests/AWSLambdaEventsTests/ALBTests.swift
+++ b/Tests/AWSLambdaEventsTests/ALBTests.swift
@@ -51,7 +51,7 @@ class ALBTests: XCTestCase {
 
             let event = try decoder.decode(ALBTargetGroupRequest.self, from: data)
 
-            XCTAssertEqual(event.httpMethod, .GET)
+            XCTAssertEqual(event.httpMethod, .get)
             XCTAssertEqual(event.body, "")
             XCTAssertEqual(event.isBase64Encoded, false)
             XCTAssertEqual(event.headers?.count, 11)

--- a/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGateway+V2Tests.swift
@@ -154,7 +154,7 @@ class APIGatewayV2Tests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayV2Request.self, from: data))
 
         XCTAssertEqual(req?.rawPath, "/hello")
-        XCTAssertEqual(req?.context.http.method, .GET)
+        XCTAssertEqual(req?.context.http.method, .get)
         XCTAssertEqual(req?.queryStringParameters?.count, 1)
         XCTAssertEqual(req?.rawQueryString, "foo=bar")
         XCTAssertEqual(req?.headers.count, 8)

--- a/Tests/AWSLambdaEventsTests/APIGatewayTests.swift
+++ b/Tests/AWSLambdaEventsTests/APIGatewayTests.swift
@@ -43,7 +43,7 @@ class APIGatewayTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayRequest.self, from: data))
 
         XCTAssertEqual(req?.path, "/test")
-        XCTAssertEqual(req?.httpMethod, .GET)
+        XCTAssertEqual(req?.httpMethod, .get)
     }
 
     func testRequestDecodingExampleGetRequestWithoutDomainName() {
@@ -52,7 +52,7 @@ class APIGatewayTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayRequest.self, from: data))
 
         XCTAssertEqual(req?.path, "/test")
-        XCTAssertEqual(req?.httpMethod, .GET)
+        XCTAssertEqual(req?.httpMethod, .get)
         XCTAssertNil(req?.requestContext.domainName)
     }
 
@@ -62,7 +62,7 @@ class APIGatewayTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayRequest.self, from: data))
 
         XCTAssertEqual(req?.path, "/test")
-        XCTAssertEqual(req?.httpMethod, .GET)
+        XCTAssertEqual(req?.httpMethod, .get)
         XCTAssertEqual(req?.requestContext.authorizer?.claims?["scope"], "aws.cognito.signin.user.admin phone openid profile email")
         XCTAssertEqual(req?.requestContext.authorizer?.claims?["username"], "richwolf")
     }
@@ -73,7 +73,7 @@ class APIGatewayTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(APIGatewayRequest.self, from: data))
 
         XCTAssertEqual(req?.path, "/todos")
-        XCTAssertEqual(req?.httpMethod, .POST)
+        XCTAssertEqual(req?.httpMethod, .post)
     }
 
     // MARK: - Response -
@@ -81,7 +81,7 @@ class APIGatewayTests: XCTestCase {
     // MARK: Encoding
 
     struct JSONResponse: Codable {
-        let statusCode: UInt
+        let statusCode: Int
         let headers: [String: String]?
         let body: String?
         let isBase64Encoded: Bool?

--- a/Tests/AWSLambdaEventsTests/FunctionURLTests.swift
+++ b/Tests/AWSLambdaEventsTests/FunctionURLTests.swift
@@ -129,7 +129,7 @@ class FunctionURLTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(FunctionURLRequest.self, from: data))
 
         XCTAssertEqual(req?.rawPath, "/my/path")
-        XCTAssertEqual(req?.requestContext.http.method, .POST)
+        XCTAssertEqual(req?.requestContext.http.method, .post)
         XCTAssertEqual(req?.queryStringParameters?.count, 2)
         XCTAssertEqual(req?.rawQueryString, "parameter1=value1&parameter1=value2&parameter2=value")
         XCTAssertEqual(req?.headers.count, 2)
@@ -142,7 +142,7 @@ class FunctionURLTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(FunctionURLRequest.self, from: data))
 
         XCTAssertEqual(req?.rawPath, "/")
-        XCTAssertEqual(req?.requestContext.http.method, .GET)
+        XCTAssertEqual(req?.requestContext.http.method, .get)
         XCTAssertEqual(req?.queryStringParameters?.count, 1)
         XCTAssertEqual(req?.rawQueryString, "test=2")
         XCTAssertEqual(req?.headers.count, 10)

--- a/Tests/AWSLambdaEventsTests/LambdaGatewayProxyEventTests.swift
+++ b/Tests/AWSLambdaEventsTests/LambdaGatewayProxyEventTests.swift
@@ -122,7 +122,7 @@ class LambdaGatewayProxyEventTests: XCTestCase {
         XCTAssertNoThrow(req = try JSONDecoder().decode(LambdaGatewayProxyEvent.self, from: data))
 
         XCTAssertEqual(req?.path, "/hello")
-        XCTAssertEqual(req?.requestContext.httpMethod, .GET)
+        XCTAssertEqual(req?.requestContext.httpMethod, .get)
         XCTAssertEqual(req?.queryStringParameters?.count, 1)
         XCTAssertEqual(req?.headers.count, 8)
         XCTAssertNotNil(req?.body)


### PR DESCRIPTION
Use Swift HTTP types package for status and method

### Motivation:

As mentioned in #46 there is some overlap between the definitions of http types in this library and in the recent [Apple Swift HTTP Types library](https://github.com/apple/swift-http-types). 

This means when working with Swift HTTP Types, you have to convert from the AWS Lambda Events representation of http types into Swift HTTP Types. 

### Modifications:

I have replaced the request method and response status Swift types in this library with those from Swift HTTP Types.

### Result:

Now you must use Swift HTTP Types for request methods and response types.

### Further discussion:

#### No Headers?

I initially indented to also replace the representation of headers to Swift HTTP Types' HTTPField, but this turned out to be... non-trivial. The way AWS encodes the different forms of headers in different situations and the way the Swift HTTP Types library handles encoding and decoding are both (of course) very different, so you can't just replace `public let headers: [String: String]` with `public let header: HTTPFields`.

I think I could have added manual encode and decode functions to the various types that have headers to support this, rather than relying on the synthized codable functions. But that seemed like overkill and a future maintenance burden that I am not in a place to decide about.

#### Extending Status and Method to add Codable support

In Swift HTTP Types, the higher level structs support Codable, but Method and Status themselves don't directly support Codable. Instead the structs that include Method and Status handle the encoding / decoding of those types. This means I've had to add a Codable implementation for Method and Status in this library. This seems a little odd to me. I wonder if that would be better placed in Swift HTTP Types?


