### PR TITLE
cleanup pre Swift 5.6 code

### DIFF
--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -18,9 +18,9 @@ import class Foundation.JSONEncoder
 
 // https://github.com/aws/aws-lambda-go/blob/master/events/alb.go
 /// `ALBTargetGroupRequest` contains data originating from the ALB Lambda target group integration.
-public struct ALBTargetGroupRequest: Codable {
+public struct ALBTargetGroupRequest: Codable, Sendable {
     /// `Context` contains information to identify the load balancer invoking the lambda.
-    public struct Context: Codable {
+    public struct Context: Codable, Sendable {
         public let elb: ELBContext
     }
 
@@ -46,12 +46,12 @@ public struct ALBTargetGroupRequest: Codable {
     public let body: String?
 
     /// `ELBContext` contains information to identify the ARN invoking the lambda.
-    public struct ELBContext: Codable {
+    public struct ELBContext: Codable, Sendable {
         public let targetGroupArn: String
     }
 }
 
-public struct ALBTargetGroupResponse: Codable {
+public struct ALBTargetGroupResponse: Codable, Sendable {
     public var statusCode: HTTPResponse.Status
     public var statusDescription: String?
     public var headers: HTTPHeaders?
@@ -75,10 +75,3 @@ public struct ALBTargetGroupResponse: Codable {
         self.isBase64Encoded = isBase64Encoded
     }
 }
-
-#if swift(>=5.6)
-extension ALBTargetGroupRequest: Sendable {}
-extension ALBTargetGroupRequest.Context: Sendable {}
-extension ALBTargetGroupRequest.ELBContext: Sendable {}
-extension ALBTargetGroupResponse: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/APIGateway+V2.swift
+++ b/Sources/AWSLambdaEvents/APIGateway+V2.swift
@@ -15,10 +15,10 @@
 import HTTPTypes
 
 /// `APIGatewayV2Request` contains data coming from the new HTTP API Gateway.
-public struct APIGatewayV2Request: Codable {
+public struct APIGatewayV2Request: Codable, Sendable {
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
-    public struct Context: Codable {
-        public struct HTTP: Codable {
+    public struct Context: Codable, Sendable {
+        public struct HTTP: Codable, Sendable {
             public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
@@ -27,9 +27,9 @@ public struct APIGatewayV2Request: Codable {
         }
 
         /// `Authorizer` contains authorizer information for the request context.
-        public struct Authorizer: Codable {
+        public struct Authorizer: Codable, Sendable {
             /// `JWT` contains JWT authorizer information for the request context.
-            public struct JWT: Codable {
+            public struct JWT: Codable, Sendable {
                 public let claims: [String: String]?
                 public let scopes: [String]?
             }
@@ -37,8 +37,8 @@ public struct APIGatewayV2Request: Codable {
             public let jwt: JWT?
 
             // `IAM` contains AWS IAM authorizer information for the request context.
-            public struct IAM: Codable {
-                public struct CognitoIdentity: Codable {
+            public struct IAM: Codable, Sendable {
+                public struct CognitoIdentity: Codable, Sendable {
                     public let amr: [String]?
                     public let identityId: String?
                     public let identityPoolId: String?
@@ -58,9 +58,9 @@ public struct APIGatewayV2Request: Codable {
             public let lambda: LambdaAuthorizerContext?
         }
 
-        public struct Authentication: Codable {
-            public struct ClientCert: Codable {
-                public struct Validity: Codable {
+        public struct Authentication: Codable, Sendable {
+            public struct ClientCert: Codable, Sendable {
+                public struct Validity: Codable, Sendable {
                     public let notBefore: String
                     public let notAfter: String
                 }
@@ -126,7 +126,7 @@ public struct APIGatewayV2Request: Codable {
     }
 }
 
-public struct APIGatewayV2Response: Codable {
+public struct APIGatewayV2Response: Codable, Sendable {
     public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var body: String?
@@ -147,17 +147,3 @@ public struct APIGatewayV2Response: Codable {
         self.cookies = cookies
     }
 }
-
-#if swift(>=5.6)
-extension APIGatewayV2Request: Sendable {}
-extension APIGatewayV2Request.Context: Sendable {}
-extension APIGatewayV2Request.Context.HTTP: Sendable {}
-extension APIGatewayV2Request.Context.Authorizer: Sendable {}
-extension APIGatewayV2Request.Context.Authorizer.JWT: Sendable {}
-extension APIGatewayV2Request.Context.Authorizer.IAM: Sendable {}
-extension APIGatewayV2Request.Context.Authorizer.IAM.CognitoIdentity: Sendable {}
-extension APIGatewayV2Request.Context.Authentication: Sendable {}
-extension APIGatewayV2Request.Context.Authentication.ClientCert: Sendable {}
-extension APIGatewayV2Request.Context.Authentication.ClientCert.Validity: Sendable {}
-extension APIGatewayV2Response: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -20,9 +20,9 @@ import class Foundation.JSONEncoder
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
 
 /// `APIGatewayRequest` contains data coming from the API Gateway.
-public struct APIGatewayRequest: Codable {
-    public struct Context: Codable {
-        public struct Identity: Codable {
+public struct APIGatewayRequest: Codable, Sendable {
+    public struct Context: Codable, Sendable {
+        public struct Identity: Codable, Sendable {
             public let cognitoIdentityPoolId: String?
 
             public let apiKey: String?
@@ -37,7 +37,7 @@ public struct APIGatewayRequest: Codable {
             public let accountId: String?
         }
 
-        public struct Authorizer: Codable {
+        public struct Authorizer: Codable, Sendable {
             public let claims: [String: String]?
         }
 
@@ -74,7 +74,7 @@ public struct APIGatewayRequest: Codable {
 
 // MARK: - Response -
 
-public struct APIGatewayResponse: Codable {
+public struct APIGatewayResponse: Codable, Sendable {
     public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var multiValueHeaders: HTTPMultiValueHeaders?
@@ -95,11 +95,3 @@ public struct APIGatewayResponse: Codable {
         self.isBase64Encoded = isBase64Encoded
     }
 }
-
-#if swift(>=5.6)
-extension APIGatewayRequest: Sendable {}
-extension APIGatewayRequest.Context: Sendable {}
-extension APIGatewayRequest.Context.Identity: Sendable {}
-extension APIGatewayRequest.Context.Authorizer: Sendable {}
-extension APIGatewayResponse: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
+++ b/Sources/AWSLambdaEvents/APIGatewayLambdaAuthorizers.swift
@@ -18,7 +18,7 @@ import HTTPTypes
 public typealias LambdaAuthorizerContext = [String: String]
 
 /// `APIGatewayLambdaAuthorizerRequest` contains the payload sent to a Lambda Authorizer function
-public struct APIGatewayLambdaAuthorizerRequest: Codable {
+public struct APIGatewayLambdaAuthorizerRequest: Codable, Sendable {
     public let version: String
     public let type: String
     public let routeArn: String?
@@ -29,8 +29,8 @@ public struct APIGatewayLambdaAuthorizerRequest: Codable {
     public let headers: [String: String]
 
     /// `Context` contains information to identify the AWS account and resources invoking the Lambda function.
-    public struct Context: Codable {
-        public struct HTTP: Codable {
+    public struct Context: Codable, Sendable {
+        public struct HTTP: Codable, Sendable {
             public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
@@ -56,7 +56,7 @@ public struct APIGatewayLambdaAuthorizerRequest: Codable {
 }
 
 /// `APIGatewayLambdaAuthorizerSimpleResponse` contains a simple response (yes/no) returned by a Lambda authorizer function
-public struct APIGatewayLambdaAuthorizerSimpleResponse: Codable {
+public struct APIGatewayLambdaAuthorizerSimpleResponse: Codable, Sendable {
     public let isAuthorized: Bool
     public let context: LambdaAuthorizerContext?
 
@@ -68,15 +68,15 @@ public struct APIGatewayLambdaAuthorizerSimpleResponse: Codable {
 }
 
 /// `APIGatewayLambdaAuthorizerPolicyResponse` contains a Policy response (inc. an IAM policy document) returned by a Lambda authorizer function
-public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
+public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable, Sendable {
     public let principalId: String
 
     /// `PolicyDocument` contains an IAM policy document
-    public struct PolicyDocument: Codable {
+    public struct PolicyDocument: Codable, Sendable {
         public let version: String
 
-        public struct Statement: Codable {
-            public enum Effect: String, Codable {
+        public struct Statement: Codable, Sendable {
+            public enum Effect: String, Codable, Sendable {
                 case allow = "Allow"
                 case deny = "Deny"
             }
@@ -121,15 +121,3 @@ public struct APIGatewayLambdaAuthorizerPolicyResponse: Codable {
         self.context = context
     }
 }
-
-#if swift(>=5.6)
-extension LambdaAuthorizerContext: Sendable {}
-extension APIGatewayLambdaAuthorizerRequest: Sendable {}
-extension APIGatewayLambdaAuthorizerRequest.Context: Sendable {}
-extension APIGatewayLambdaAuthorizerRequest.Context.HTTP: Sendable {}
-extension APIGatewayLambdaAuthorizerSimpleResponse: Sendable {}
-extension APIGatewayLambdaAuthorizerPolicyResponse: Sendable {}
-extension APIGatewayLambdaAuthorizerPolicyResponse.PolicyDocument: Sendable {}
-extension APIGatewayLambdaAuthorizerPolicyResponse.PolicyDocument.Statement: Sendable {}
-extension APIGatewayLambdaAuthorizerPolicyResponse.PolicyDocument.Statement.Effect: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/AWSRegion.swift
+++ b/Sources/AWSLambdaEvents/AWSRegion.swift
@@ -16,7 +16,7 @@
 //   $ aws ssm get-parameters-by-path --path /aws/service/global-infrastructure/services/lambda/regions --output json
 
 /// Enumeration of the AWS Regions.
-public struct AWSRegion: RawRepresentable, Equatable {
+public struct AWSRegion: RawRepresentable, Equatable, Sendable {
     public typealias RawValue = String
 
     public let rawValue: String
@@ -107,7 +107,3 @@ extension AWSRegion: Codable {
         try container.encode(self.rawValue)
     }
 }
-
-#if swift(>=5.6)
-extension AWSRegion: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -146,7 +146,7 @@ public struct AppSyncEvent: Decodable, Sendable {
     }
 }
 
-public enum AppSyncResponse<ResultType: Encodable & Sendable>: Encodable, Sendable {
+public enum AppSyncResponse<ResultType: Encodable>: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -165,3 +165,4 @@ public enum AppSyncResponse<ResultType: Encodable & Sendable>: Encodable, Sendab
 }
 
 public typealias AppSyncJSONResponse = AppSyncResponse<String>
+extension AppSyncResponse: Sendable where ResultType: Sendable {}

--- a/Sources/AWSLambdaEvents/AppSync.swift
+++ b/Sources/AWSLambdaEvents/AppSync.swift
@@ -15,10 +15,10 @@
 import HTTPTypes
 
 // https://docs.aws.amazon.com/appsync/latest/devguide/resolver-context-reference.html
-public struct AppSyncEvent: Decodable {
+public struct AppSyncEvent: Decodable, Sendable {
     public let arguments: [String: ArgumentValue]
 
-    public enum ArgumentValue: Codable {
+    public enum ArgumentValue: Codable, Sendable {
         case string(String)
         case dictionary([String: String])
 
@@ -48,7 +48,7 @@ public struct AppSyncEvent: Decodable {
     }
 
     public let request: Request
-    public struct Request: Decodable {
+    public struct Request: Decodable, Sendable {
         let headers: HTTPHeaders
     }
 
@@ -56,7 +56,7 @@ public struct AppSyncEvent: Decodable {
     public let stash: [String: String]?
 
     public let info: Info
-    public struct Info: Codable {
+    public struct Info: Codable, Sendable {
         public var selectionSetList: [String]
         public var selectionSetGraphQL: String
         public var parentTypeName: String
@@ -65,11 +65,11 @@ public struct AppSyncEvent: Decodable {
     }
 
     public let identity: Identity?
-    public enum Identity: Codable {
+    public enum Identity: Codable, Sendable {
         case iam(IAMIdentity)
         case cognitoUserPools(CognitoUserPoolIdentity)
 
-        public struct IAMIdentity: Codable {
+        public struct IAMIdentity: Codable, Sendable {
             public let accountId: String
             public let cognitoIdentityPoolId: String
             public let cognitoIdentityId: String
@@ -80,7 +80,7 @@ public struct AppSyncEvent: Decodable {
             public let cognitoIdentityAuthProvider: String
         }
 
-        public struct CognitoUserPoolIdentity: Codable {
+        public struct CognitoUserPoolIdentity: Codable, Sendable {
             public let defaultAuthStrategy: String
             public let issuer: String
             public let sourceIp: [String]
@@ -146,7 +146,7 @@ public struct AppSyncEvent: Decodable {
     }
 }
 
-public enum AppSyncResponse<ResultType: Encodable>: Encodable {
+public enum AppSyncResponse<ResultType: Encodable & Sendable>: Encodable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -165,14 +165,3 @@ public enum AppSyncResponse<ResultType: Encodable>: Encodable {
 }
 
 public typealias AppSyncJSONResponse = AppSyncResponse<String>
-
-#if swift(>=5.6)
-extension AppSyncEvent: Sendable {}
-extension AppSyncEvent.ArgumentValue: Sendable {}
-extension AppSyncEvent.Request: Sendable {}
-extension AppSyncEvent.Info: Sendable {}
-extension AppSyncEvent.Identity: Sendable {}
-extension AppSyncEvent.Identity.CognitoUserPoolIdentity: Sendable {}
-extension AppSyncEvent.Identity.IAMIdentity: Sendable {}
-extension AppSyncResponse: Sendable where ResultType: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/CloudFormation.swift
+++ b/Sources/AWSLambdaEvents/CloudFormation.swift
@@ -13,10 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 // CloudFormation custom resource.
-public enum CloudFormation {
+public enum CloudFormation: Sendable {
     // Request represents the request body of AWS::CloudFormation::CustomResource.
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
-    public struct Request<R: Decodable, O: Decodable>: Decodable {
+    public struct Request<R: Decodable & Sendable, O: Decodable & Sendable>: Decodable {
         public enum RequestType: String, Decodable {
             case create = "Create"
             case update = "Update"
@@ -59,8 +59,8 @@ public enum CloudFormation {
 
     // Response represents the response body of AWS::CloudFormation::CustomResource.
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
-    public struct Response<D: Encodable>: Encodable {
-        public enum StatusType: String, Encodable {
+    public struct Response<D: Encodable & Sendable>: Encodable, Sendable {
+        public enum StatusType: String, Encodable, Sendable {
             case success = "SUCCESS"
             case failed = "FAILED"
         }

--- a/Sources/AWSLambdaEvents/CloudFormation.swift
+++ b/Sources/AWSLambdaEvents/CloudFormation.swift
@@ -16,8 +16,8 @@
 public enum CloudFormation: Sendable {
     // Request represents the request body of AWS::CloudFormation::CustomResource.
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
-    public struct Request<R: Decodable & Sendable, O: Decodable & Sendable>: Decodable {
-        public enum RequestType: String, Decodable {
+    public struct Request<R: Decodable, O: Decodable>: Decodable {
+        public enum RequestType: String, Decodable, Sendable {
             case create = "Create"
             case update = "Update"
             case delete = "Delete"
@@ -59,7 +59,7 @@ public enum CloudFormation: Sendable {
 
     // Response represents the response body of AWS::CloudFormation::CustomResource.
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
-    public struct Response<D: Encodable & Sendable>: Encodable, Sendable {
+    public struct Response<D: Encodable>: Encodable {
         public enum StatusType: String, Encodable, Sendable {
             case success = "SUCCESS"
             case failed = "FAILED"
@@ -119,3 +119,6 @@ public enum CloudFormation: Sendable {
         }
     }
 }
+
+extension CloudFormation.Request: Sendable where R: Sendable, O: Sendable {}
+extension CloudFormation.Response: Sendable where D: Sendable {}

--- a/Sources/AWSLambdaEvents/Cognito.swift
+++ b/Sources/AWSLambdaEvents/Cognito.swift
@@ -108,7 +108,7 @@ extension CognitoEvent: Codable {
     }
 }
 
-public enum CognitoEventResponse: Sendable{
+public enum CognitoEventResponse: Sendable {
     case preSignUpSignUp(CognitoEvent.Parameters, CognitoEvent.PreSignUp, PreSignUp)
 
     public struct PreSignUp: Codable, Hashable, Sendable {

--- a/Sources/AWSLambdaEvents/Cognito.swift
+++ b/Sources/AWSLambdaEvents/Cognito.swift
@@ -12,18 +12,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-enum CognitoEventError: Error {
+enum CognitoEventError: Error, Sendable {
     case unimplementedEvent(String)
 }
 
 /// https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html
-public enum CognitoEvent: Equatable {
-    public struct CallerContext: Codable, Hashable {
+public enum CognitoEvent: Equatable, Sendable {
+    public struct CallerContext: Codable, Hashable, Sendable {
         let awsSdkVersion: String
         let clientId: String
     }
 
-    public struct Parameters: Codable, Equatable {
+    public struct Parameters: Codable, Equatable, Sendable {
         let version: String
         let triggerSource: String
         let region: AWSRegion
@@ -34,7 +34,7 @@ public enum CognitoEvent: Equatable {
 
     case preSignUpSignUp(Parameters, PreSignUp)
 
-    public struct PreSignUp: Codable, Hashable {
+    public struct PreSignUp: Codable, Hashable, Sendable {
         /// One or more name-value pairs representing user attributes. The attribute names are the keys.
         public let userAttributes: [String: String]
         /// One or more name-value pairs containing the validation data in the request to register a user.
@@ -108,10 +108,10 @@ extension CognitoEvent: Codable {
     }
 }
 
-public enum CognitoEventResponse {
+public enum CognitoEventResponse: Sendable{
     case preSignUpSignUp(CognitoEvent.Parameters, CognitoEvent.PreSignUp, PreSignUp)
 
-    public struct PreSignUp: Codable, Hashable {
+    public struct PreSignUp: Codable, Hashable, Sendable {
         public let autoConfirmUser: Bool
         public let autoVerifyPhone: Bool
         public let autoVerifyEmail: Bool

--- a/Sources/AWSLambdaEvents/DynamoDB.swift
+++ b/Sources/AWSLambdaEvents/DynamoDB.swift
@@ -19,39 +19,39 @@ import struct Foundation.Date
 #endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
-public struct DynamoDBEvent: Decodable {
+public struct DynamoDBEvent: Decodable, Sendable {
     public let records: [EventRecord]
 
-    public enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey, Sendable {
         case records = "Records"
     }
 
-    public enum KeyType: String, Codable {
+    public enum KeyType: String, Codable, Sendable {
         case hash = "HASH"
         case range = "RANGE"
     }
 
-    public enum OperationType: String, Codable {
+    public enum OperationType: String, Codable, Sendable {
         case insert = "INSERT"
         case modify = "MODIFY"
         case remove = "REMOVE"
     }
 
-    public enum SharedIteratorType: String, Codable {
+    public enum SharedIteratorType: String, Codable, Sendable {
         case trimHorizon = "TRIM_HORIZON"
         case latest = "LATEST"
         case atSequenceNumber = "AT_SEQUENCE_NUMBER"
         case afterSequenceNumber = "AFTER_SEQUENCE_NUMBER"
     }
 
-    public enum StreamStatus: String, Codable {
+    public enum StreamStatus: String, Codable, Sendable {
         case enabling = "ENABLING"
         case enabled = "ENABLED"
         case disabling = "DISABLING"
         case disabled = "DISABLED"
     }
 
-    public enum StreamViewType: String, Codable {
+    public enum StreamViewType: String, Codable, Sendable {
         /// The entire item, as it appeared after it was modified.
         case newImage = "NEW_IMAGE"
         /// The entire item, as it appeared before it was modified.
@@ -62,7 +62,7 @@ public struct DynamoDBEvent: Decodable {
         case keysOnly = "KEYS_ONLY"
     }
 
-    public struct EventRecord: Decodable {
+    public struct EventRecord: Decodable, Sendable {
         /// The region in which the GetRecords request was received.
         public let awsRegion: AWSRegion
 
@@ -117,7 +117,7 @@ public struct DynamoDBEvent: Decodable {
         }
     }
 
-    public struct StreamRecord {
+    public struct StreamRecord: Sendable {
         /// The approximate date and time when the stream record was created, in UNIX
         /// epoch time (http://www.epochconverter.com/) format.
         public let approximateCreationDateTime: Date?
@@ -142,7 +142,7 @@ public struct DynamoDBEvent: Decodable {
         public let streamViewType: StreamViewType
     }
 
-    public struct UserIdentity: Codable {
+    public struct UserIdentity: Codable, Sendable {
         public let type: String
         public let principalId: String
     }
@@ -191,7 +191,7 @@ extension DynamoDBEvent.StreamRecord: Decodable {
 // MARK: - AttributeValue -
 
 extension DynamoDBEvent {
-    public enum AttributeValue {
+    public enum AttributeValue: Sendable {
         case boolean(Bool)
         case binary([UInt8])
         case binarySet([[UInt8]])
@@ -381,7 +381,7 @@ extension DynamoDBEvent {
         }
     }
 
-    struct ArrayKey: CodingKey, Equatable {
+    struct ArrayKey: CodingKey, Equatable, Sendable {
         init(index: Int) {
             self.intValue = index
         }
@@ -934,13 +934,3 @@ extension DynamoDBEvent.AttributeValue {
         }
     }
 }
-
-#if swift(>=5.6)
-extension DynamoDBEvent: Sendable {}
-extension DynamoDBEvent.EventRecord: Sendable {}
-extension DynamoDBEvent.StreamRecord: Sendable {}
-extension DynamoDBEvent.UserIdentity: Sendable {}
-extension DynamoDBEvent.OperationType: Sendable {}
-extension DynamoDBEvent.AttributeValue: Sendable {}
-extension DynamoDBEvent.StreamViewType: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/FunctionURL.swift
+++ b/Sources/AWSLambdaEvents/FunctionURL.swift
@@ -18,10 +18,10 @@ import class Foundation.JSONEncoder
 // https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html
 
 /// FunctionURLRequest contains data coming from a bare Lambda Function URL
-public struct FunctionURLRequest: Codable {
-    public struct Context: Codable {
-        public struct Authorizer: Codable {
-            public struct IAMAuthorizer: Codable {
+public struct FunctionURLRequest: Codable, Sendable {
+    public struct Context: Codable, Sendable {
+        public struct Authorizer: Codable, Sendable {
+            public struct IAMAuthorizer: Codable, Sendable {
                 public let accessKey: String
 
                 public let accountId: String
@@ -37,7 +37,7 @@ public struct FunctionURLRequest: Codable {
             public let iam: IAMAuthorizer?
         }
 
-        public struct HTTP: Codable {
+        public struct HTTP: Codable, Sendable {
             public let method: HTTPRequest.Method
             public let path: String
             public let `protocol`: String
@@ -81,7 +81,7 @@ public struct FunctionURLRequest: Codable {
 
 // MARK: - Response -
 
-public struct FunctionURLResponse: Codable {
+public struct FunctionURLResponse: Codable, Sendable {
     public var statusCode: HTTPResponse.Status
     public var headers: HTTPHeaders?
     public var body: String?
@@ -102,12 +102,3 @@ public struct FunctionURLResponse: Codable {
         self.isBase64Encoded = isBase64Encoded
     }
 }
-
-#if swift(>=5.6)
-extension FunctionURLRequest: Sendable {}
-extension FunctionURLRequest.Context: Sendable {}
-extension FunctionURLRequest.Context.Authorizer: Sendable {}
-extension FunctionURLRequest.Context.Authorizer.IAMAuthorizer: Sendable {}
-extension FunctionURLRequest.Context.HTTP: Sendable {}
-extension FunctionURLResponse: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/LambdaGatewayProxyEvent.swift
+++ b/Sources/AWSLambdaEvents/LambdaGatewayProxyEvent.swift
@@ -15,10 +15,10 @@
 import HTTPTypes
 
 /// LambdaGatewayProxyEvent contains data coming from the new HTTP API Gateway Proxy
-public struct LambdaGatewayProxyEvent: Decodable {
-    public struct RequestContext: Decodable {
+public struct LambdaGatewayProxyEvent: Decodable, Sendable {
+    public struct RequestContext: Decodable, Sendable {
         /// Authorizer contains authorizer information for the request context.
-        public struct Authorizer: Codable {
+        public struct Authorizer: Codable, Sendable {
             public let claims: [String: String]?
             public let scopes: [String]?
         }
@@ -75,9 +75,3 @@ public struct LambdaGatewayProxyEvent: Decodable {
     public let body: String?
     public let isBase64Encoded: Bool
 }
-
-#if swift(>=5.6)
-extension LambdaGatewayProxyEvent: Sendable {}
-extension LambdaGatewayProxyEvent.RequestContext: Sendable {}
-extension LambdaGatewayProxyEvent.RequestContext.Authorizer: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/S3.swift
+++ b/Sources/AWSLambdaEvents/S3.swift
@@ -16,8 +16,8 @@ import struct Foundation.Date
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-s3.html
 
-public struct S3Event: Decodable {
-    public struct Record: Decodable {
+public struct S3Event: Decodable, Sendable {
+    public struct Record: Decodable, Sendable {
         public let eventVersion: String
         public let eventSource: String
         public let awsRegion: AWSRegion
@@ -37,15 +37,15 @@ public struct S3Event: Decodable {
         case records = "Records"
     }
 
-    public struct RequestParameters: Codable, Equatable {
+    public struct RequestParameters: Codable, Equatable, Sendable {
         public let sourceIPAddress: String
     }
 
-    public struct UserIdentity: Codable, Equatable {
+    public struct UserIdentity: Codable, Equatable, Sendable {
         public let principalId: String
     }
 
-    public struct Entity: Codable {
+    public struct Entity: Codable, Sendable {
         public let configurationId: String
         public let schemaVersion: String
         public let bucket: Bucket
@@ -59,13 +59,13 @@ public struct S3Event: Decodable {
         }
     }
 
-    public struct Bucket: Codable {
+    public struct Bucket: Codable, Sendable {
         public let name: String
         public let ownerIdentity: UserIdentity
         public let arn: String
     }
 
-    public struct Object: Codable {
+    public struct Object: Codable, Sendable {
         public let key: String
         /// The object's size in bytes.
         ///
@@ -77,13 +77,3 @@ public struct S3Event: Decodable {
         public let sequencer: String
     }
 }
-
-#if swift(>=5.6)
-extension S3Event: Sendable {}
-extension S3Event.Bucket: Sendable {}
-extension S3Event.Entity: Sendable {}
-extension S3Event.Object: Sendable {}
-extension S3Event.Record: Sendable {}
-extension S3Event.RequestParameters: Sendable {}
-extension S3Event.UserIdentity: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/SES.swift
+++ b/Sources/AWSLambdaEvents/SES.swift
@@ -16,8 +16,8 @@ import struct Foundation.Date
 
 // https://docs.aws.amazon.com/lambda/latest/dg/services-ses.html
 
-public struct SESEvent: Decodable {
-    public struct Record: Decodable {
+public struct SESEvent: Decodable, Sendable {
+    public struct Record: Decodable, Sendable {
         public let eventSource: String
         public let eventVersion: String
         public let ses: Message
@@ -29,12 +29,12 @@ public struct SESEvent: Decodable {
         case records = "Records"
     }
 
-    public struct Message: Decodable {
+    public struct Message: Decodable, Sendable {
         public let mail: Mail
         public let receipt: Receipt
     }
 
-    public struct Mail: Decodable {
+    public struct Mail: Decodable, Sendable {
         public let commonHeaders: CommonHeaders
         public let destination: [String]
         public let headers: [Header]
@@ -44,7 +44,7 @@ public struct SESEvent: Decodable {
         @ISO8601WithFractionalSecondsCoding public var timestamp: Date
     }
 
-    public struct CommonHeaders: Decodable {
+    public struct CommonHeaders: Decodable, Sendable {
         public let bcc: [String]?
         public let cc: [String]?
         @RFC5322DateTimeCoding public var date: Date
@@ -55,12 +55,12 @@ public struct SESEvent: Decodable {
         public let to: [String]?
     }
 
-    public struct Header: Decodable {
+    public struct Header: Decodable, Sendable {
         public let name: String
         public let value: String
     }
 
-    public struct Receipt: Decodable {
+    public struct Receipt: Decodable, Sendable {
         public let action: Action
         public let dmarcPolicy: DMARCPolicy?
         public let dmarcVerdict: Verdict?
@@ -73,40 +73,26 @@ public struct SESEvent: Decodable {
         public let virusVerdict: Verdict
     }
 
-    public struct Action: Decodable {
+    public struct Action: Decodable, Sendable {
         public let functionArn: String
         public let invocationType: String
         public let type: String
     }
 
-    public struct Verdict: Decodable {
+    public struct Verdict: Decodable, Sendable {
         public let status: Status
     }
 
-    public enum DMARCPolicy: String, Decodable {
+    public enum DMARCPolicy: String, Decodable, Sendable {
         case none
         case quarantine
         case reject
     }
 
-    public enum Status: String, Decodable {
+    public enum Status: String, Decodable, Sendable {
         case pass = "PASS"
         case fail = "FAIL"
         case gray = "GRAY"
         case processingFailed = "PROCESSING_FAILED"
     }
 }
-
-#if swift(>=5.6)
-extension SESEvent: Sendable {}
-extension SESEvent.Record: Sendable {}
-extension SESEvent.Message: Sendable {}
-extension SESEvent.Mail: Sendable {}
-extension SESEvent.Receipt: Sendable {}
-extension SESEvent.CommonHeaders: Sendable {}
-extension SESEvent.Action: Sendable {}
-extension SESEvent.Header: Sendable {}
-extension SESEvent.DMARCPolicy: Sendable {}
-extension SESEvent.Verdict: Sendable {}
-extension SESEvent.Status: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -16,8 +16,8 @@ import struct Foundation.Date
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
 
-public struct SNSEvent: Decodable {
-    public struct Record: Decodable {
+public struct SNSEvent: Decodable, Sendable {
+    public struct Record: Decodable, Sendable {
         public let eventVersion: String
         public let eventSubscriptionArn: String
         public let eventSource: String
@@ -37,8 +37,8 @@ public struct SNSEvent: Decodable {
         case records = "Records"
     }
 
-    public struct Message {
-        public enum Attribute {
+    public struct Message: Sendable {
+        public enum Attribute: Sendable {
             case string(String)
             case binary([UInt8])
         }
@@ -104,10 +104,3 @@ extension SNSEvent.Message.Attribute: Decodable {
         }
     }
 }
-
-#if swift(>=5.6)
-extension SNSEvent: Sendable {}
-extension SNSEvent.Record: Sendable {}
-extension SNSEvent.Message: Sendable {}
-extension SNSEvent.Message.Attribute: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/SQS.swift
+++ b/Sources/AWSLambdaEvents/SQS.swift
@@ -14,16 +14,16 @@
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
 
-public struct SQSEvent: Decodable {
+public struct SQSEvent: Decodable, Sendable {
     public let records: [Message]
 
     enum CodingKeys: String, CodingKey {
         case records = "Records"
     }
 
-    public struct Message {
+    public struct Message: Sendable {
         /// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html
-        public enum Attribute {
+        public enum Attribute: Sendable {
             case string(String)
             case binary([UInt8])
             case number(String)
@@ -93,9 +93,3 @@ extension SQSEvent.Message.Attribute: Decodable {
         }
     }
 }
-
-#if swift(>=5.6)
-extension SQSEvent: Sendable {}
-extension SQSEvent.Message: Sendable {}
-extension SQSEvent.Message.Attribute: Sendable {}
-#endif

--- a/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
+++ b/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
@@ -22,7 +22,7 @@ import struct Foundation.Locale
 import struct Foundation.TimeZone
 
 @propertyWrapper
-public struct ISO8601Coding: Decodable {
+public struct ISO8601Coding: Decodable, Sendable {
     public let wrappedValue: Date
 
     public init(wrappedValue: Date) {
@@ -49,7 +49,7 @@ public struct ISO8601Coding: Decodable {
 }
 
 @propertyWrapper
-public struct ISO8601WithFractionalSecondsCoding: Decodable {
+public struct ISO8601WithFractionalSecondsCoding: Decodable, Sendable {
     public let wrappedValue: Date
 
     public init(wrappedValue: Date) {
@@ -76,7 +76,7 @@ public struct ISO8601WithFractionalSecondsCoding: Decodable {
 }
 
 @propertyWrapper
-public struct RFC5322DateTimeCoding: Decodable {
+public struct RFC5322DateTimeCoding: Decodable, Sendable {
     public let wrappedValue: Date
 
     public init(wrappedValue: Date) {
@@ -113,9 +113,3 @@ public struct RFC5322DateTimeCoding: Decodable {
         return [formatterWithDay, formatterWithoutDay]
     }
 }
-
-#if swift(>=5.6)
-extension ISO8601Coding: Sendable {}
-extension ISO8601WithFractionalSecondsCoding: Sendable {}
-extension RFC5322DateTimeCoding: Sendable {}
-#endif


### PR DESCRIPTION
The code base uses pre compiler directives to selectively add `Sendable` protocol to `struct` when compiling on Swift >= 5.6

```
#if swift(>=5.6)
extension XXX: Sendable
#endif
```

This PR removes this old code and moves all `Sendable` definitions to the same line as the `struct` definition.

```
public struct XXX: Sendable
```

