### PR TITLE
Update DynamoDB.Decoder to handle binary strings

### DIFF
--- a/Sources/AWSLambdaEvents/DynamoDB.swift
+++ b/Sources/AWSLambdaEvents/DynamoDB.swift
@@ -17,6 +17,7 @@ import struct Foundation.Date
 #else
 @preconcurrency import struct Foundation.Date
 #endif
+import struct Foundation.Data
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
 public struct DynamoDBEvent: Decodable, Sendable {
@@ -619,11 +620,14 @@ extension DynamoDBEvent {
         }
 
         func decode(_: String.Type) throws -> String {
-            guard case .string(let string) = self.value else {
+            switch self.value {
+            case .string(let string):
+                return string
+            case .binary(let binary):
+                return Data(binary).base64EncodedString()
+            default:
                 throw self.createTypeMismatchError(type: String.self, value: self.value)
             }
-
-            return string
         }
 
         func decode(_: Double.Type) throws -> Double {


### PR DESCRIPTION
DynamoDBEvent.Decoder isn't currently handling the case where .binary attributes are base64encoded strings and throws an error

### Motivation:

If you try to use DynamoDBEvent.Decoder on binary values, it throws an error saying it is expecting the value to be a string

### Modifications:

Decoding string values now handles the case where they are .binary as well

### Result:

If you have a DynamoDB record with binary values, you will be able to use DynamoDBEvent.Decoder to properly decode it without an error being thrown
