### PR TITLE
Use FoundationEssentials if possible

### DIFF
--- a/Sources/AWSLambdaEvents/ALB.swift
+++ b/Sources/AWSLambdaEvents/ALB.swift
@@ -14,7 +14,11 @@
 
 import HTTPTypes
 
-import class Foundation.JSONEncoder
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://github.com/aws/aws-lambda-go/blob/master/events/alb.go
 /// `ALBTargetGroupRequest` contains data originating from the ALB Lambda target group integration.

--- a/Sources/AWSLambdaEvents/APIGateway.swift
+++ b/Sources/AWSLambdaEvents/APIGateway.swift
@@ -14,7 +14,11 @@
 
 import HTTPTypes
 
-import class Foundation.JSONEncoder
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html
 // https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html

--- a/Sources/AWSLambdaEvents/Cloudwatch.swift
+++ b/Sources/AWSLambdaEvents/Cloudwatch.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
 #else
-@preconcurrency import struct Foundation.Date
+import Foundation
 #endif
 
 /// EventBridge has the same events/notification types as CloudWatch

--- a/Sources/AWSLambdaEvents/DynamoDB.swift
+++ b/Sources/AWSLambdaEvents/DynamoDB.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
 #else
-@preconcurrency import struct Foundation.Date
+import Foundation
 #endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html

--- a/Sources/AWSLambdaEvents/FunctionURL.swift
+++ b/Sources/AWSLambdaEvents/FunctionURL.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import HTTPTypes
 
-import class Foundation.JSONEncoder
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html
 

--- a/Sources/AWSLambdaEvents/S3.swift
+++ b/Sources/AWSLambdaEvents/S3.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-s3.html
 

--- a/Sources/AWSLambdaEvents/SES.swift
+++ b/Sources/AWSLambdaEvents/SES.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/services-ses.html
 

--- a/Sources/AWSLambdaEvents/SNS.swift
+++ b/Sources/AWSLambdaEvents/SNS.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 // https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
 

--- a/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
+++ b/Sources/AWSLambdaEvents/Utils/DateWrappers.swift
@@ -12,14 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-import struct Foundation.Date
+#if canImport(FoundationEssentials)
+import FoundationEssentials
 #else
-@preconcurrency import struct Foundation.Date
+import Foundation
 #endif
-import class Foundation.DateFormatter
-import struct Foundation.Locale
-import struct Foundation.TimeZone
 
 @propertyWrapper
 public struct ISO8601Coding: Decodable, Sendable {


### PR DESCRIPTION
In order to reduce binary size, we want to depend only on FoundationEssentials on Linux.

We should add CI in the future that checks, that we don't link full Foundation.