### PR TITLE
Use GitHub actions for CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,29 @@
+name: PR
+
+on:
+    pull_request:
+      types: [opened, reopened, synchronize]
+
+jobs:
+    soundness:
+        name: Soundness
+        uses: apple/swift-nio/.github/workflows/soundness.yml@main
+        with:
+            license_header_check_project_name: "SwiftAWSLambdaEvents"
+            shell_check_enabled: false
+            api_breakage_check_container_image: "swiftlang/swift:nightly-6.0-jammy"
+            docs_check_container_image: "swiftlang/swift:nightly-6.0-jammy"
+
+    unit-tests:
+        name: Unit tests
+        uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
+        with:
+            linux_5_8_enabled: true
+            linux_5_9_enabled: true
+            linux_5_10_enabled: true
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+
+    swift-6-language-mode:
+        name: Swift 6 Language Mode
+        uses: apple/swift-nio/.github/workflows/swift_6_language_mode.yml@main


### PR DESCRIPTION
Use GitHub actions for CI

### Motivation:

- We like GitHub actions

### Modifications:

- Add workflow

### Result:

- We will be able to deprecate our existing CI
