### PR TITLE
CognitoEvent CallerContext ClientId should be optional

### DIFF
--- a/Sources/AWSLambdaEvents/Cognito.swift
+++ b/Sources/AWSLambdaEvents/Cognito.swift
@@ -23,7 +23,7 @@ public enum CognitoEvent: Equatable, Sendable {
         public let awsSdkVersion: String
 
         /// The ID of the user pool app client.
-        public let clientId: String
+        public let clientId: String?
     }
 
     /// https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-identity-pools-working-with-aws-lambda-trigger-sources


### PR DESCRIPTION
Just a small change, the clientId is only sent if the request came from a client, not if e.g. you do it in the console or use AdminUpdateUserAttributes directly (not via an app client)