### PR TITLE
add .index-build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.build
+*.index-build
 /.xcodeproj
 *.pem
 .podspecs


### PR DESCRIPTION
.index-build is a temporary build directory created by the VSCode plugin for Swift