### PR TITLE
Make S3 eTag optional

### DIFF
--- a/Sources/AWSLambdaEvents/S3.swift
+++ b/Sources/AWSLambdaEvents/S3.swift
@@ -77,7 +77,7 @@ public struct S3Event: Decodable, Sendable {
         public let size: UInt64?
         public let urlDecodedKey: String?
         public let versionId: String?
-        public let eTag: String
+        public let eTag: String?
         public let sequencer: String
     }
 }


### PR DESCRIPTION
Make S3 Object eTag optional, because it's not always there.

### Motivation:

I'm seeing real events without an eTag, which naturally is causing decoding failures.

### Modifications:

Made S3 Object eTag optional.

### Result:

S3 Object eTag is now optional...
