### PR TITLE
Update .gitignore to ignore .devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 xcuserdata
 Package.resolved
 .serverless
+.devcontainer


### PR DESCRIPTION
`.devcontainer` should not be versioned to allow developers to customize it without git to interfere