### PR TITLE
Add an init() that match the APIGatewayResponse

### DIFF
--- a/Sources/AWSLambdaEvents/FunctionURL.swift
+++ b/Sources/AWSLambdaEvents/FunctionURL.swift
@@ -92,12 +92,27 @@ public struct FunctionURLResponse: Codable, Sendable {
     public let cookies: [String]?
     public var isBase64Encoded: Bool?
 
+    @available(*, deprecated, message: "Use init(statusCode:headers:body:isBase64Encoded:cookies:) instead")
     public init(
         statusCode: HTTPResponse.Status,
         headers: HTTPHeaders? = nil,
         body: String? = nil,
         cookies: [String]? = nil,
         isBase64Encoded: Bool? = nil
+    ) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+        self.cookies = cookies
+        self.isBase64Encoded = isBase64Encoded
+    }
+
+    public init(
+        statusCode: HTTPResponse.Status,
+        headers: HTTPHeaders? = nil,
+        body: String? = nil,
+        isBase64Encoded: Bool? = nil,
+        cookies: [String]? = nil
     ) {
         self.statusCode = statusCode
         self.headers = headers


### PR DESCRIPTION
Add an `init()` to `FunctionURLResponse` to match the signature of `APIGatewayv2Response`

### Motivation:

`APIGAtewayV2Response` and `FunctionURLResponse` share teh same structure, although we provided two different signatures for the initializers. This prevent writing common code to handle both responses.

### Modifications:

- add a new `init(0` that has the same signature as the init from APIGatewayV2response
- make the current init as deprecated, we will remove it in a future version bump

### Result:

Two init() functions on FunctionURLResponse
