### PR TITLE
fix: Add support for DISABLED status in SES verdict enums (#110)

### DIFF
--- a/Sources/AWSLambdaEvents/SES.swift
+++ b/Sources/AWSLambdaEvents/SES.swift
@@ -98,6 +98,7 @@ public struct SESEvent: Decodable, Sendable {
         case pass = "PASS"
         case fail = "FAIL"
         case gray = "GRAY"
+        case disabled = "DISABLED"
         case processingFailed = "PROCESSING_FAILED"
     }
 }

--- a/Tests/AWSLambdaEventsTests/SESTests.swift
+++ b/Tests/AWSLambdaEventsTests/SESTests.swift
@@ -158,7 +158,9 @@ struct SESTests {
         }
         """
 
-    @Test(arguments: [(SESTests.eventBody, SESEvent.Status.pass), (SESTests.eventBodyDisabled, SESEvent.Status.disabled)])
+    @Test(arguments: [
+        (SESTests.eventBody, SESEvent.Status.pass), (SESTests.eventBodyDisabled, SESEvent.Status.disabled),
+    ])
     func simpleEventFromJSON(input: (String, SESEvent.Status)) throws {
         let data = Data(input.0.utf8)
         let event = try JSONDecoder().decode(SESEvent.self, from: data)

--- a/Tests/AWSLambdaEventsTests/SESTests.swift
+++ b/Tests/AWSLambdaEventsTests/SESTests.swift
@@ -89,8 +89,78 @@ struct SESTests {
         }
         """
 
-    @Test func simpleEventFromJSON() throws {
-        let data = Data(SESTests.eventBody.utf8)
+    static let eventBodyDisabled = """
+        {
+          "Records": [
+            {
+              "eventSource": "aws:ses",
+              "eventVersion": "1.0",
+              "ses": {
+                "mail": {
+                  "commonHeaders": {
+                    "date": "Wed, 7 Oct 2015 12:34:56 -0700",
+                    "from": [
+                      "Jane Doe <janedoe@example.com>"
+                    ],
+                    "messageId": "<0123456789example.com>",
+                    "returnPath": "janedoe@example.com",
+                    "subject": "Test Subject",
+                    "to": [
+                      "johndoe@example.com"
+                    ]
+                  },
+                  "destination": [
+                    "johndoe@example.com"
+                  ],
+                  "headers": [
+                    {
+                      "name": "Return-Path",
+                      "value": "<janedoe@example.com>"
+                    },
+                    {
+                      "name": "Received",
+                      "value": "from mailer.example.com (mailer.example.com [203.0.113.1]) by inbound-smtp.eu-west-1.amazonaws.com with SMTP id o3vrnil0e2ic28trm7dfhrc2v0cnbeccl4nbp0g1 for johndoe@example.com; Wed, 07 Oct 2015 12:34:56 +0000 (UTC)"
+                    }
+                  ],
+                  "headersTruncated": true,
+                  "messageId": "5h5auqp1oa1bg49b2q8f8tmli1oju8pcma2haao1",
+                  "source": "janedoe@example.com",
+                  "timestamp": "1970-01-01T00:00:00.000Z"
+                },
+                "receipt": {
+                  "action": {
+                    "functionArn": "arn:aws:lambda:eu-west-1:123456789012:function:Example",
+                    "invocationType": "Event",
+                    "type": "Lambda"
+                  },
+                  "dkimVerdict": {
+                    "status": "PASS"
+                  },
+                  "processingTimeMillis": 574,
+                  "recipients": [
+                    "test@swift-server.com",
+                    "test2@swift-server.com"
+                  ],
+                  "spamVerdict": {
+                    "status": "DISABLED"
+                  },
+                  "spfVerdict": {
+                    "status": "PROCESSING_FAILED"
+                  },
+                  "timestamp": "1970-01-01T00:00:00.000Z",
+                  "virusVerdict": {
+                    "status": "FAIL"
+                  }
+                }
+              }
+            }
+          ]
+        }
+        """
+
+    @Test(arguments: [SESTests.eventBody, SESTests.eventBodyDisabled])
+    func simpleEventFromJSON(event: String) throws {
+        let data = Data(event.utf8)
         let event = try JSONDecoder().decode(SESEvent.self, from: data)
         let record = try #require(event.records.first)
 
@@ -122,7 +192,7 @@ struct SESTests {
         #expect(record.ses.receipt.processingTimeMillis == 574)
         #expect(record.ses.receipt.recipients[0] == "test@swift-server.com")
         #expect(record.ses.receipt.recipients[1] == "test2@swift-server.com")
-        #expect(record.ses.receipt.spamVerdict.status == .pass)
+        #expect(record.ses.receipt.spamVerdict.status == .pass || record.ses.receipt.spamVerdict.status == .disabled)
         #expect(record.ses.receipt.spfVerdict.status == .processingFailed)
         #expect(record.ses.receipt.timestamp.description == "1970-01-01 00:00:00 +0000")
         #expect(record.ses.receipt.virusVerdict.status == .fail)

--- a/Tests/AWSLambdaEventsTests/SESTests.swift
+++ b/Tests/AWSLambdaEventsTests/SESTests.swift
@@ -158,9 +158,9 @@ struct SESTests {
         }
         """
 
-    @Test(arguments: [SESTests.eventBody, SESTests.eventBodyDisabled])
-    func simpleEventFromJSON(event: String) throws {
-        let data = Data(event.utf8)
+    @Test(arguments: [(SESTests.eventBody, SESEvent.Status.pass), (SESTests.eventBodyDisabled, SESEvent.Status.disabled)])
+    func simpleEventFromJSON(input: (String, SESEvent.Status)) throws {
+        let data = Data(input.0.utf8)
         let event = try JSONDecoder().decode(SESEvent.self, from: data)
         let record = try #require(event.records.first)
 
@@ -192,7 +192,7 @@ struct SESTests {
         #expect(record.ses.receipt.processingTimeMillis == 574)
         #expect(record.ses.receipt.recipients[0] == "test@swift-server.com")
         #expect(record.ses.receipt.recipients[1] == "test2@swift-server.com")
-        #expect(record.ses.receipt.spamVerdict.status == .pass || record.ses.receipt.spamVerdict.status == .disabled)
+        #expect(record.ses.receipt.spamVerdict.status == input.1)
         #expect(record.ses.receipt.spfVerdict.status == .processingFailed)
         #expect(record.ses.receipt.timestamp.description == "1970-01-01 00:00:00 +0000")
         #expect(record.ses.receipt.virusVerdict.status == .fail)


### PR DESCRIPTION
## Motivation:
AWS SES can return "`DISABLED`" as a valid status value for spam, virus, DKIM, and SPF verdicts when certain checks are disabled in the SES configuration. However, the `SESEvent.Receipt.Verdict.Status` enum was missing this case, causing JSON decoding to fail with a `DecodingError` when parsing SES events containing `{"status":"DISABLED"}`.

This issue was reported in #110, where users encountered parsing failures when processing legitimate SES events from AWS that included disabled verdict checks.

## Modifications:
Added `.disabled = "DISABLED"` case to the `SESEvent.Receipt.Verdict.Status` enum in 
SES.swift
Converted the existing test to a parameterized test using Swift Testing's `@Test(arguments:)` syntax
Added a new test case (`eventBodyDisabled`) that includes a SES event with `spamVerdict.status` set to "`DISABLED`"
Updated the test assertion to verify both `.pass` and `.disabled` status values are handled correctly

## Result:
SES events with verdict statuses set to "`DISABLED`" will now decode successfully without throwing errors. The library correctly handles all valid AWS SES verdict status values: `PASS`, `FAIL`, `GRAY`, `PROCESSING_FAILED`, and `DISABLED`. The parameterized test ensures both standard and disabled verdict scenarios are validated automatically.